### PR TITLE
Tactic show_no_hamiltonian_path that uses a SAT solver to prove the graph has no ham path

### DIFF
--- a/LeanHoG/Invariant/HamiltonianPath/Correctness.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Correctness.lean
@@ -54,7 +54,7 @@ abbrev e {g : Graph} (k k' : Fin g.vertexSize) :
   let is := List.finRange n
   let js := List.finRange n
   let pairs := is ×ˢ js
-  let non_edges := List.filter (fun (i,j) => ¬ (g.badjacent i j)) pairs
+  let non_edges := List.filter (fun (i,j) => ¬ (g.adjacent i j)) pairs
   conj_list (non_edges |>.map fun (i,j) => disj_list [(x i k)ᶜ, (x j k')ᶜ])
 
 @[simp] lemma satisfies_a_iff {n : Nat} {i : Fin n} {τ : PropAssignment (Pos n)} :
@@ -125,7 +125,7 @@ abbrev e {g : Graph} (k k' : Fin g.vertexSize) :
 
 @[simp] lemma satisfies_e_iff {g : Graph} {k k' : Fin g.vertexSize}
   {τ : PropAssignment (Pos g.vertexSize)} :
-  τ ⊨ e k k' ↔ ∀ i j, ¬ g.badjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ := by
+  τ ⊨ e k k' ↔ ∀ i j, ¬ g.adjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ := by
   apply Iff.intro
   · intros h i j not_edge
     simp [satisfies_conj_list] at h
@@ -238,7 +238,7 @@ abbrev has_hamiltonian_path (g : Graph) :=
 @[simp] lemma satisfies_no_non_edges_iff {g : Graph} {τ : PropAssignment (Pos g.vertexSize)} :
   τ ⊨ no_non_edges g ↔
   ∀ (k k' : Fin g.vertexSize), k.val + 1 =  k'.val →
-  ∀ i j, ¬ g.badjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ := by
+  ∀ i j, ¬ g.adjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ := by
   apply Iff.intro
   · intros h k k' rel
     simp [satisfies_conj_list, List.mem_filter] at h
@@ -249,14 +249,15 @@ abbrev has_hamiltonian_path (g : Graph) :=
     simp [satisfies_conj_list, List.mem_filter]
     intro p x x_1 a a_1
     aesop_subst a_1
-    simp_all only [satisfies_e_iff, Bool.not_eq_true, satisfies_neg, satisfies_var, implies_true]
+    simp_all only [Pos, satisfies_neg, satisfies_var, Bool.not_eq_true, satisfies_e_iff, not_false_eq_true,
+      implies_true]
 
 @[simp] lemma satisfies_has_hamiltonian_path_iff {g : Graph} {τ : PropAssignment (Pos g.vertexSize)} :
   τ ⊨ has_hamiltonian_path g ↔
   (∀ i, ∃ j, τ ⊨ x i j ∧ (∀ j k, j ≠ k → τ ⊨ (x i j)ᶜ ∨ τ ⊨ (x i k)ᶜ)) ∧
   (∀ j, ∃ i, τ ⊨ x i j ∧ (∀ i k, i ≠ k → τ ⊨ (x i j)ᶜ ∨ τ ⊨ (x k j)ᶜ)) ∧
   (∀ k k', k.val + 1 =  k'.val →
-    ∀ i j, ¬ g.badjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ
+    ∀ i j, ¬ g.adjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ
   ) := by
   simp_all only [Pos, satisfies_conj, satisfies_at_least_one_at_pos_iff, satisfies_c_iff, satisfies_var,
     satisfies_at_most_one_at_pos_iff, satisfies_d_iff, ne_eq, satisfies_neg, Bool.not_eq_true,
@@ -407,7 +408,7 @@ lemma hamiltonian_path_to_assignment_expanded {g : Graph} :
     (∀ i, ∃ j, τ ⊨ x i j ∧ (∀ j k, j ≠ k → τ ⊨ (x i j)ᶜ ∨ τ ⊨ (x i k)ᶜ)) ∧
     (∀ j, ∃ i, τ ⊨ x i j ∧ (∀ i k, i ≠ k → τ ⊨ (x i j)ᶜ ∨ τ ⊨ (x k j)ᶜ)) ∧
     (∀ k k', k.val + 1 =  k'.val →
-      ∀ i j, ¬ g.badjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ))
+      ∀ i j, ¬ g.adjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ))
   := by
   intro h
   let ⟨τ, cond⟩ := hamiltonian_path_to_assignment h
@@ -424,7 +425,7 @@ theorem unsat_to_no_hamiltonian_path_expanded {g : Graph} :
     (∀ i, ∃ j, τ ⊨ x i j ∧ (∀ j k, j ≠ k → τ ⊨ (x i j)ᶜ ∨ τ ⊨ (x i k)ᶜ)) ∧
     (∀ j, ∃ i, τ ⊨ x i j ∧ (∀ i k, i ≠ k → τ ⊨ (x i j)ᶜ ∨ τ ⊨ (x k j)ᶜ)) ∧
     (∀ k k', k.val + 1 =  k'.val →
-      ∀ i j, ¬ g.badjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ)) →
+      ∀ i j, ¬ g.adjacent i j → τ ⊨ (x i k)ᶜ ∨ τ ⊨ (x j k')ᶜ)) →
   (¬ ∃ (u v : g.vertex) (p : Path g u v), p.isHamiltonian) := by
   apply imp_neg hamiltonian_path_to_assignment_expanded
 

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -4,9 +4,11 @@ import LeanHoG.LoadGraph
 import LeanHoG.Invariant.HamiltonianPath.SatEncoding
 import LeanHoG.Tactic.Options
 
+import LeanSAT
+
 namespace LeanHoG
 
-open Lean Widget Elab Command Term Meta Qq
+open Lean Widget Elab Command Term Meta Qq LeanSAT Model Tactic
 
 -- def loadHamiltonianPathData (filePath : System.FilePath) : IO HamiltonianPathData := do
 --   let fileContent ← IO.FS.readFile filePath
@@ -16,7 +18,6 @@ open Lean Widget Elab Command Term Meta Qq
 
 syntax (name := computeHamiltonianPath) "#compute_hamiltonian_path " ident : command
 
-open ProofWidgets in
 @[command_elab computeHamiltonianPath]
 unsafe def computeHamiltonianPathImpl : CommandElab
   | `(#compute_hamiltonian_path $g ) => liftTermElabM do
@@ -46,6 +47,70 @@ unsafe def computeHamiltonianPathImpl : CommandElab
     }
     Lean.Meta.addInstance hamiltonianPathName .scoped 42
     logInfo "found Hamiltonian path"
+
+  | _ => throwUnsupportedSyntax
+
+syntax (name := showNoHamiltonianPath) "#show_no_hamiltonian_path " ident : command
+
+unsafe def showNoHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) : TermElabM (Name × Q(Prop)) := do
+    let G ← evalExpr' Graph ``Graph graph
+    let enc := (hamiltonianPathCNF G).val
+    -- let cadicalExe := "/home/jure/source-control/cadical/build/cadical"
+    -- let cake_lprExr := "/home/jure/source-control/cake_lpr/cake_lpr"
+    -- let solver := LeanSAT.Solver.Impl.CakeLpr cadicalExe #["--no-binary"] cake_lprExr
+    let solver : LeanSAT.Solver IO := (LeanSAT.Solver.Impl.DimacsCommand "/home/jure/source-control/cadical/build/cadical")
+    let cnf := Encode.EncCNF.toICnf enc
+    let res ← solver.solve cnf
+    match res with
+    | .sat _sol =>
+      throwError "graph has Hamiltonian path"
+    | .unsat =>
+      -- The formula is UNSAT, add an axiom saying so
+      let declName : Name := .str graphName "noHamiltonianPathCertificateExists"
+      let type : Q(Prop) := q(¬ (∃ (τ : PropAssignment (Var (Graph.vertexSize $graph))), τ |> hamiltonianPathConstraints $graph))
+      let decl := Declaration.axiomDecl {
+        name        := declName,
+        levelParams := [],
+        type        := type,
+        isUnsafe    := false
+      }
+      trace[Elab.axiom] "{declName} : {type}"
+      Term.ensureNoUnassignedMVars decl
+      addDecl decl
+      return (declName, type)
+    | .error => throwError "SAT solver exited with error"
+
+/-- `#show_no_hamiltonian_path G` runs a SAT solver on the encoding of the Hamiltonian path problem
+    on the graph `G` and if the SAT solver says the problem is unsat it runs the produced proof
+    through a verified proof checker cake_lpr. If the checker agrees with the proof, we add an axiom
+    saying there exists no satisfying assignmment for the encoding.
+-/
+@[command_elab showNoHamiltonianPath]
+unsafe def showNoHamiltonianPathImpl : CommandElab
+  | `(#show_no_hamiltonian_path $g ) => liftTermElabM do
+    let graphName := g.getId
+    let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
+    let (declName, type) ← showNoHamiltonianPathAux graphName graph
+    logInfo m!"added axiom {declName} : {type}"
+
+  | _ => throwUnsupportedSyntax
+
+syntax (name := showNoHamiltonianPathTactic) "show_no_hamiltonian_path " ident : tactic
+
+@[tactic showNoHamiltonianPathTactic]
+unsafe def showNoHamiltonianPathTacticImpl : Tactic
+  | `(tactic|show_no_hamiltonian_path $g) =>
+    withMainContext do
+      let graphName := g.getId
+      let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
+      let (declName, type) ← showNoHamiltonianPathAux graphName graph
+      let noExistsCert ← Tactic.elabTermEnsuringType (mkIdent declName) type
+      let noExistsHamPath ← mkAppM ``LeanHoG.no_assignment_implies_no_hamiltonian_path' #[noExistsCert]
+      let noExistsType := q(¬ ∃ (u v : Graph.vertex $graph) (p : Path $graph u v), p.isHamiltonian)
+      liftMetaTactic fun mvarId => do
+        let mvarIdNew ← mvarId.assert .anonymous noExistsType noExistsHamPath
+        let (_, mvarIdNew) ← mvarIdNew.intro1P
+        return [mvarIdNew]
 
   | _ => throwUnsupportedSyntax
 

--- a/LeanHoG/Tactic/Basic.lean
+++ b/LeanHoG/Tactic/Basic.lean
@@ -10,7 +10,7 @@ import Std.Data.List.Basic
 
 namespace LeanHoG
 
-open Lean Widget Elab Command Term Meta Qq Tactic Qq
+open Lean Widget Elab Command Term Meta Qq Tactic
 
 /-- Evaluate an expression into a Nat -/
 unsafe def evaluateNat (e : Expr) : MetaM Nat := do


### PR DESCRIPTION
For the given graph construct a verified CNF describing the existence of a Hamiltonian path in the graph.
Then run a SAT solver on the resulting CNF and check the unsat proof produced by the solver with a verified proof checker. If the proof checker says the proof is valid, add an axiom saying that no assignment exists satisfying the encoding. From this deduce that no Hamiltonian path exists in a graph. The tactic adds this as an assumption to the context.

Usage:
```
show_no_hamiltonia_path G
```
adds an annonymous hypothesis of type `(¬ ∃ (u v : G.vertex) (p : Path G u v), p.isHamiltonian)` to the context.

- [ ] Currently the verified proof checker phase isn't implemented yet.
- [ ] Add a `with h` to the syntax to allow naming the introduced hypotheiss
- [ ] Add a warning saying we introduced a new axiom