### PR TITLE
Rename the connected components certificate instance in LoadGraph

### DIFF
--- a/LeanHoG/LoadGraph.lean
+++ b/LeanHoG/LoadGraph.lean
@@ -47,7 +47,7 @@ unsafe def loadGraphAux (graphName : Name) (jsonData : JSONData) : Elab.Command.
   match jsonData.connectedComponents? with
   | .none => pure ()
   | .some data =>
-    let componentsCertificateName := certificateName graphName "CertificateI"
+    let componentsCertificateName := certificateName graphName "ConnectedComponentsCertificateI"
     let componentsCertificateQ : Q(ConnectedComponentsCertificate $graph) := connectedComponentsCertificateOfData graph data
     Elab.Command.liftCoreM <| addAndCompile <| .defnDecl {
       name := componentsCertificateName


### PR DESCRIPTION
It used to be called `CertificateI`, it should be `ConnectedComponentsCertificateI` or similar.