### PR TITLE
Import every module from the root

### DIFF
--- a/LeanHoG.lean
+++ b/LeanHoG.lean
@@ -1,1 +1,12 @@
+import LeanHoG.Certificate
+import LeanHoG.Edge
+import LeanHoG.Graph
+import LeanHoG.Invariant
+import LeanHoG.JsonData
 import LeanHoG.LoadGraph
+import LeanHoG.Options
+import LeanHoG.Tactic
+import LeanHoG.Util
+import LeanHoG.VertexColoring
+import LeanHoG.Walk
+import LeanHoG.Widgets

--- a/LeanHoG/Invariant.lean
+++ b/LeanHoG/Invariant.lean
@@ -1,0 +1,5 @@
+import LeanHoG.Invariant.Bipartite
+import LeanHoG.Invariant.ConnectedComponents
+import LeanHoG.Invariant.G6
+import LeanHoG.Invariant.HamiltonianPath
+import LeanHoG.Invariant.NeighborhoodMap

--- a/LeanHoG/Invariant/Bipartite.lean
+++ b/LeanHoG/Invariant/Bipartite.lean
@@ -1,0 +1,3 @@
+import LeanHoG.Invariant.Bipartite.Basic
+import LeanHoG.Invariant.Bipartite.Certificate
+import LeanHoG.Invariant.Bipartite.JsonData

--- a/LeanHoG/Invariant/ConnectedComponents.lean
+++ b/LeanHoG/Invariant/ConnectedComponents.lean
@@ -1,0 +1,3 @@
+import LeanHoG.Invariant.ConnectedComponents.Basic
+import LeanHoG.Invariant.ConnectedComponents.Certificate
+import LeanHoG.Invariant.ConnectedComponents.JsonData

--- a/LeanHoG/Invariant/HamiltonianPath.lean
+++ b/LeanHoG/Invariant/HamiltonianPath.lean
@@ -1,0 +1,7 @@
+import LeanHoG.Invariant.HamiltonianPath.Basic
+import LeanHoG.Invariant.HamiltonianPath.Certificate
+import LeanHoG.Invariant.HamiltonianPath.Correctness
+import LeanHoG.Invariant.HamiltonianPath.JsonData
+import LeanHoG.Invariant.HamiltonianPath.SatEncoding
+import LeanHoG.Invariant.HamiltonianPath.SatHelpers
+import LeanHoG.Invariant.HamiltonianPath.Tactic

--- a/LeanHoG/Invariant/NeighborhoodMap.lean
+++ b/LeanHoG/Invariant/NeighborhoodMap.lean
@@ -1,0 +1,3 @@
+import LeanHoG.Invariant.NeighborhoodMap.Basic
+import LeanHoG.Invariant.NeighborhoodMap.Certificate
+import LeanHoG.Invariant.NeighborhoodMap.JsonData

--- a/LeanHoG/Tactic.lean
+++ b/LeanHoG/Tactic.lean
@@ -1,0 +1,4 @@
+import LeanHoG.Tactic.Basic
+import LeanHoG.Tactic.Options
+import LeanHoG.Tactic.ParseExpr
+import LeanHoG.Tactic.SearchDSL

--- a/LeanHoG/Util.lean
+++ b/LeanHoG/Util.lean
@@ -1,0 +1,6 @@
+import LeanHoG.Util.LeanSAT
+import LeanHoG.Util.List
+import LeanHoG.Util.PackageDir
+import LeanHoG.Util.Quote
+import LeanHoG.Util.RB
+import LeanHoG.Util.TrestleStd


### PR DESCRIPTION
Closes the code half of #47. Rewritten to @dMaggot's suggestion — imports from the
root rather than a glob on the default target. The branch name is now a misnomer;
there is no glob in it.

## The problem

`LeanHoG.lean` was one line, `import LeanHoG.LoadGraph`, and a Lake library is a
root module plus its import closure. Measured in a clean worktree off 5af17fa:
that closure is **27 of the 36 modules** under `LeanHoG/`. Nine were never
compiled by `lake build`, which reported success anyway:

```
Invariant/HamiltonianPath/Tactic     Tactic/Options
Options                              Tactic/ParseExpr
Tactic/Basic                         Tactic/SearchDSL
Util/LeanSAT                         Util/PackageDir
Widgets
```

Not just the SAT/LRAT pair — the whole tactic front-end, plus `Widgets`. That is
the green under which #45 rewrote `LeanSAT.lean` and #46 changed it and
`HamiltonianPath/Tactic.lean`, with the changed code never compiled.

## The change

A per-directory aggregator for `Tactic`, `Util` and each `Invariant` subtree, and
`LeanHoG.lean` importing them:

```lean
import LeanHoG.Certificate
import LeanHoG.Edge
import LeanHoG.Graph
import LeanHoG.Invariant
import LeanHoG.JsonData
import LeanHoG.LoadGraph
import LeanHoG.Options
import LeanHoG.Tactic
import LeanHoG.Util
import LeanHoG.VertexColoring
import LeanHoG.Walk
import LeanHoG.Widgets
```

`lakefile.lean` is untouched.

## It fixes more than the build

Imports make the modules *available*, not merely compiled, and that turned out to
be a live bug. `check_traceable` was unreachable from `import LeanHoG` — a user
had to know to import the leaf module by hand:

```lean
-- import LeanHoG.LoadGraph  (what the old root gave you)
example : True := by
  check_traceable nonexistentGraph
-- error: unknown tactic

-- import LeanHoG  (this branch)
example : True := by
  check_traceable nonexistentGraph
-- error: Unknown identifier `nonexistentGraph`   ← tactic resolves
```

A glob would have compiled those modules without fixing this.

## Verification

Clean `git worktree` off 5af17fa, no prior build directory.

| | jobs | modules built |
|---|---|---|
| `main` as-is | 3255, "Build completed successfully" | 27 of 36 |
| this branch | 3285, exit 0 | **43 of 43** (36 + 7 aggregators) |

Plus the differential above, run both ways with `lake env lean`.

## Two notes

- `Widgets` is now in the root import graph, and it `include_str`s the npm bundle,
  so consumers load it. Left in for completeness; say the word if it should be
  excluded.
- The import list is now the thing that has to stay complete, and it will drift
  the first time someone adds a file and forgets. Mathlib keeps its equivalent
  honest with `lake exe mk_all --check`, and that executable is already reachable
  here since mathlib is a dependency. Filed as part of #57 rather than added here.
- `LeanHoG/Options.lean` registers `hog.pythonExecutable` while
  `LeanHoG/Tactic/Options.lean` registers `leanHoG.pythonExecutable`. No clash, so
  importing both is fine, but the former looks vestigial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*— Claude (Claude Code), posting from @lucyhorowitz's account*
