### PR TITLE
Document that check_traceable asserts, and add check_traceablea

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -98,6 +98,31 @@ load_graph hog_896 "build/graphs/896.json"
 #check_traceable hog_896
 #show_hamiltonian_path hog_896
 
+-- The command only reports what it found. To use the result in a proof there is
+-- a tactic of the same name, without the leading `#`. The tactic does not need
+-- the command to have been run on the graph first: each example below uses a
+-- graph that no `#check_traceable` above has touched.
+
+-- `check_traceable` adds the fact it derives to the context as a hypothesis. It
+-- does not close the goal, and the hypothesis is the unfolded existential rather
+-- than `¬ G.traceable`, so the proof is finished with `assumption`.
+#download Fork 30
+example : ¬Fork.traceable := by
+  check_traceable Fork
+  assumption
+
+-- `with h` gives that hypothesis a name instead of leaving it inaccessible.
+#download HGraph 334
+example : ¬HGraph.traceable := by
+  check_traceable HGraph with h
+  exact h
+
+-- `check_traceablea` performs the `assumption` step itself, in the same spirit as
+-- `simpa` for `simp`.
+#download Cross 208
+example : ¬Cross.traceable := by
+  check_traceablea Cross
+
 ---------------------------------------
 -- Tactics
 ---------------------------------------

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -90,10 +90,15 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
 ------------------------------------------
 
 syntax (name := checkTraceable) "#check_traceable " ident : command
-/-- `#check_nontraceable G` runs a SAT solver on the encoding of the Hamiltonian path problem
+/-- `#check_traceable G` runs a SAT solver on the encoding of the Hamiltonian path problem
     on the graph `G`. If the SAT solver says the problem is unsatisfiable, Lean's built-in
     verified LRAT checker checks the produced proof. If the checker accepts it, we add an axiom
     saying there is no satisfying assignment for the encoding.
+
+    This is the *command* form: it reports what it found and, when there is a Hamiltonian
+    path, registers it as an instance. It proves nothing about the current goal — see the
+    `check_traceable` tactic for that. The two are independent: the tactic does not require
+    the command to have been run on `G` first.
 -/
 @[command_elab checkTraceable]
 unsafe def checkTraceableImpl : Command.CommandElab
@@ -111,40 +116,81 @@ unsafe def checkTraceableImpl : Command.CommandElab
 ------------------------------------------
 -- Find Hamiltonian path tactic
 ------------------------------------------
--- TODO: Remove code duplication once I figure out how to do it corectly.
+
+open Trestle Model in
+/-- Run the Hamiltonian path search on `g` and add what it establishes to the local
+    context as a hypothesis named `h`. Shared by the `check_traceable` and
+    `check_traceablea` tactics.
+-/
+unsafe def assertTraceabilityFact (g : Ident) (h : Name) : Tactic.TacticM Unit :=
+  Tactic.withMainContext do
+    let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
+    let (type, proof, _) ← searchForHamiltonianPathAux g.getId graph
+    Tactic.liftMetaTactic fun mvarId => do
+      let mvarIdNew ← mvarId.assert h type proof
+      let (_, mvarIdNew) ← mvarIdNew.intro1P
+      return [mvarIdNew]
 
 syntax (name := checkTraceableTactic) "check_traceable " ident (" with" (ppSpace colGt ident))? : tactic
-open Trestle Model in
-/-- `#check_traceable G` runs a SAT solver on the encoding of the Hamiltonian path problem
+/-- `check_traceable G` runs a SAT solver on the encoding of the Hamiltonian path problem
     on the graph `G`. If the SAT solver says the problem is unsatisfiable, Lean's built-in
     verified LRAT checker checks the produced proof. If the checker accepts it, we add an axiom
     saying there is no satisfying assignment for the encoding. The tactic uses the new axiom and
     the encoding correctness theorem to deduce that there is no Hamiltonian path in the graph,
     then adds that result as a hypothesis to the current context.
 
-    Can also use `#check_traceable G with h` to save the hypothesis into the variable `h`.
+    **This tactic adds a hypothesis; it does not close the goal.** The hypothesis is the
+    unfolded existential, not `¬ G.traceable`, so finish with `assumption` (or use
+    `check_traceablea`, which does that for you):
+
+    ```lean
+    example : ¬hog_896.traceable := by
+      check_traceable hog_896
+      assumption
+    ```
+
+    `check_traceable G with h` names the hypothesis `h` instead of leaving it inaccessible:
+
+    ```lean
+    example : ¬hog_896.traceable := by
+      check_traceable hog_896 with h
+      exact h
+    ```
+
+    The tactic is self-contained — it does not require `#check_traceable G` to have been
+    run on `G` beforehand.
 -/
 @[tactic checkTraceableTactic]
 unsafe def checkTraceableTacticImpl : Tactic.Tactic
-  | `(tactic|check_traceable $g) =>
-    Tactic.withMainContext do
-      let graphName := g.getId
-      let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
-      let (val, type, _) ← searchForHamiltonianPathAux graphName graph
-      Tactic.liftMetaTactic fun mvarId => do
-        let mvarIdNew ← mvarId.assert .anonymous val type
-        let (_, mvarIdNew) ← mvarIdNew.intro1P
-        return [mvarIdNew]
+  | `(tactic|check_traceable $g) => assertTraceabilityFact g .anonymous
+  | `(tactic|check_traceable $g with $h) => assertTraceabilityFact g h.getId
+  | _ => throwUnsupportedSyntax
 
-  | `(tactic|check_traceable $g with $ident) =>
+syntax (name := checkTraceableaTactic) "check_traceablea " ident : tactic
+/-- `check_traceablea G` is `check_traceable G` followed by `assumption`, in the same spirit
+    as `simpa` for `simp`: it derives the fact about Hamiltonian paths in `G` and then uses
+    it to close the goal, rather than leaving it in the context.
+
+    ```lean
+    example : ¬hog_896.traceable := by
+      check_traceablea hog_896
+    ```
+
+    Use `check_traceable` when the derived fact is a step rather than the whole proof.
+-/
+@[tactic checkTraceableaTactic]
+unsafe def checkTraceableaTacticImpl : Tactic.Tactic
+  | `(tactic|check_traceablea $g) => do
+    assertTraceabilityFact g .anonymous
     Tactic.withMainContext do
-      let graphName := g.getId
-      let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
-      let (val, type, _) ← searchForHamiltonianPathAux graphName graph
       Tactic.liftMetaTactic fun mvarId => do
-        let mvarIdNew ← mvarId.assert ident.getId val type
-        let (_, mvarIdNew) ← mvarIdNew.intro1P
-        return [mvarIdNew]
+        try
+          mvarId.assumption
+          return []
+        catch _ =>
+          throwError "check_traceablea derived a fact about Hamiltonian paths in {g}, but it \
+            does not close the goal. Use `check_traceable {g} with h` to name it and finish \
+            the proof by hand."
 
   | _ => throwUnsupportedSyntax
 


### PR DESCRIPTION
Closes #55, following the design settled there: document the current behaviour and add `check_traceablea` alongside it.

- The `check_traceable` docstring now says that it asserts a hypothesis and does not close the goal, that the hypothesis is the unfolded existential rather than `¬ G.traceable`, and shows the `assumption` and `with h` forms.
- `check_traceablea` runs `assumption` afterwards. If that fails it reports so and points at `check_traceable G with h`.
- Three new examples, each on its own small non-traceable graph: Fork (HoG 30, 5 vertices), H graph (334, 6), Cross (208, 6), each pulled with `#download`. None of them has `#check_traceable` run on it, so the examples also show that the tactic does not need the command.

All three are connected, unlike the existing `hog_896` (`2K_2 U 2K_1`), which is non-traceable because it is disconnected.

Two additional things: the two duplicated tactic branches are now a single `assertTraceabilityFact`, which retires the `TODO: Remove code duplication` above them; and two docstring names were wrong — the command called itself `#check_nontraceable` and the tactic called itself `#check_traceable`.

Verified with `lake build Examples`, which needs `cadical` on `PATH`. All three examples elaborate. Checked separately that bare `check_traceable` still leaves the goal state described in #55, and that `check_traceablea` errors on a goal it cannot close.
