### PR TITLE
Bring verifyAllGraphs up to date with main, and fix the download path

### DIFF
--- a/Download/downloadGraph.py
+++ b/Download/downloadGraph.py
@@ -25,7 +25,10 @@ class GraphsCache():
         print(f'Downloading invariants metadata.')
         with requests.get(self.invariants_API_url) as response:
             if not response:
-                sys.stderr.write(f'Failed to download invariants info')
+                # Nothing downstream works without the metadata, so this is fatal
+                # rather than a warning to carry on past.
+                raise RuntimeError(
+                    f'Failed to download invariants info: HTTP {response.status_code}')
             with open(self.invariants_path, 'w') as fh:
                 json.dump(response.json(), fh)
                 print(f'\rInvariants downloaded.', end=None)
@@ -46,26 +49,49 @@ class GraphsCache():
         return f'{GraphsCache.graph_url(id)}/invariants'
 
     def _get_invariants(self, id : int):
-        invariants = None
+        """
+        The invariant values for one graph, or None if HoG does not have them.
+
+        Note a nonexistent id answers 200 here with a body holding only `_links`,
+        so the status code on its own is not enough to tell.
+        """
         with requests.get(self.invariants_url(id)) as response_inv:
-            if response_inv:
-                invariants = response_inv.json()
-            else:
-                sys.stderr.write(f"Failed to download invariants for graph {id}")
+            if not response_inv:
+                sys.stderr.write(
+                    f"Failed to download invariants for graph {id}: "
+                    f"HTTP {response_inv.status_code}\n")
+                return None
+            invariants = response_inv.json()
+        if "_embedded" not in invariants:
+            sys.stderr.write(f"HoG has no invariants for graph {id}.\n")
+            return None
         return invariants
 
-    def download_graph(self, id : int):
+    def download_graph(self, id : int) -> bool:
+        """
+        Download one graph into the cache directory. Returns whether it was written.
+
+        HoG ids are not contiguous, so a missing id is an ordinary outcome of
+        walking a range and reported as a skip rather than raised.
+        """
         print(f'Downloading graph with ID {id}.')
         with requests.get(self.graph_url(id)) as response:
             if not response:
-                sys.stderr.write(f"Failed to download graph {id}")
-            invariants = Invariants(self._get_invariants(id), self.invariants_metadata)
-            graph = Graph(id, response.json(), invariants)
-            with open(os.path.join(self.dest_dir, "{0}.json".format(id)), 'w') as fh:
-                json.dump(graph, fh, cls=GraphEncoder)
-                print(f"\rDownloaded graph with ID {id}.", end=None)
+                sys.stderr.write(
+                    f"Failed to download graph {id}: HTTP {response.status_code}\n")
+                return False
+            graph_data = response.json()
+        raw_invariants = self._get_invariants(id)
+        if raw_invariants is None:
+            return False
+        invariants = Invariants(raw_invariants, self.invariants_metadata)
+        graph = Graph(id, graph_data, invariants)
+        with open(os.path.join(self.dest_dir, "{0}.json".format(id)), 'w') as fh:
+            json.dump(graph, fh, cls=GraphEncoder)
+        print(f"\rDownloaded graph with ID {id}.", end=None)
+        return True
 
 if __name__ == '__main__':
     gc = GraphsCache(dest_dir = sys.argv[1])
     id = int(sys.argv[2])
-    gc.download_graph(id)
+    sys.exit(0 if gc.download_graph(id) else 1)

--- a/Download/invariants.py
+++ b/Download/invariants.py
@@ -1,5 +1,34 @@
 import json
-from typing import Dict, Union
+import math
+from typing import Dict, Optional, Union
+
+# Values HoG uses for "there is no finite value here". It is not consistent about
+# which one it picks: a disconnected graph can come back with diameter
+# "Infinity" but radius null, and an acyclic one with girth null rather than
+# "Infinity", so both spellings have to be handled for the same situation.
+NO_VALUE_STRINGS = ("Infinity", "-Infinity", "NaN")
+
+
+def coerceValue(typeName : str, value) -> Optional[Union[bool, int, float]]:
+    """
+    Convert a raw HoG invariant value to the type its metadata declares.
+
+    Returns None when HoG has no usable value, which callers should read as
+    "invariant absent" rather than as an error: around half the graphs in HoG
+    have at least one, so treating it as an error means most of the database
+    cannot be downloaded at all.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value in NO_VALUE_STRINGS:
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if typeName == "b":
+        return bool(value)
+    if typeName == "i":
+        return int(value)
+    return value
 
 
 class Invariant():
@@ -7,8 +36,9 @@ class Invariant():
     id : int
     name : str
     fieldName : str
-    value : Union[bool, int, float]
-    
+    # None when HoG has no finite value for this invariant on this graph.
+    value : Optional[Union[bool, int, float]]
+
     def _setFieldName(self):
         """Convert invariant names"""
         s = self.name.title()
@@ -21,25 +51,33 @@ class Invariant():
         self.id = id
         self.name = name
         self._setFieldName()
-        if typeName == "b":
-            self.value = bool(value)
-        elif typeName == "i":
-            self.value = int(value)
-        else:
-            self.value = value
+        self.value = coerceValue(typeName, value)
 
 
 class Invariants():
     """An object representing values of invariants for a graph"""
 
-    invariant_values : Dict[int, Invariant] = {}
+    invariant_values : Dict[int, Invariant]
 
     def __init__(self, values, metadata) -> None:
+        # Per instance, deliberately. As a class attribute with a `= {}` default
+        # this dict was shared by every Invariants ever built, so downloading
+        # several graphs in one process wrote each graph's invariants into the
+        # next graph's JSON. Harmless while downloadGraph.py was one graph per
+        # process; silent data corruption for anything that batches.
+        self.invariant_values = {}
         raw_invariant_values = Invariants._parse_invariants(values)
         for e in metadata["_embedded"]["invariantModelList"]:
             id = e["entity"]["invariantId"]
-            value = raw_invariant_values[id]
-            self.invariant_values[id] = Invariant(id, e["entity"]["invariantName"], e["entity"]["typeName"], value)
+            # `.get`: HoG may omit an invariant from a graph's list entirely,
+            # which is the same situation as an explicit null.
+            invariant = Invariant(id, e["entity"]["invariantName"], e["entity"]["typeName"],
+                                  raw_invariant_values.get(id))
+            # Absent invariants are left out of the JSON rather than written as
+            # null. Every field of `RawHoGData` is an `Option`, and Lean's
+            # derived `FromJson` reads a missing field as `none`.
+            if invariant.value is not None:
+                self.invariant_values[id] = invariant
 
     @staticmethod
     def _parse_invariants(invariants_data) -> Dict[int, Union[bool, int, float]]:

--- a/Examples.lean
+++ b/Examples.lean
@@ -8,7 +8,7 @@ import LeanHoG.Invariant.HamiltonianPath.Tactic
 namespace LeanHoG
 
 -- You may have to change this
-set_option leanHoG.pythonExecutable "/Users/katja/Git/Lean-HoG/.venv/bin/python"
+set_option leanHoG.pythonExecutable "python"
 
 -----------------------------------------
 -- Loading graphs, visualizing them, and

--- a/Examples.lean
+++ b/Examples.lean
@@ -105,17 +105,14 @@ load_graph hog_896 "build/graphs/896.json"
 -- Tactic to close goals of the form ∃ G, P G
 -- Not all P are supported, only propositions using invariants defined
 -- Note: To check for Hamiltonian paths, we use a SAT solver.
--- If the solver says the problem is unsat, we check it's proof with a
--- verified proof checker.
+-- If the solver says the problem is unsat, we check its proof with the
+-- verified LRAT checker from `Std`.
 -- For this you need to have a solver installed, capable of producing
--- LRAT proofs of unsat. We recommend CaDiCal 1.9.5+ (https://github.com/arminbiere/cadical)
--- and cake_lpr (https://github.com/tanyongkiam/cake_lpr).
--- We set the location of the solver and proof checker with user options
--- `leanHoG.solverCmd` and `leanHoG.proofCheckerCmd`.
--- Uncomment lines below to run the tactic
+-- LRAT proofs of unsat. We recommend CaDiCal 1.9.5+ (https://github.com/arminbiere/cadical).
+-- We set the location of the solver with the user option `leanHoG.solverCmd`.
+-- Uncomment the line below to run the tactic
 
 -- set_option leanHoG.solverCmd "cadical"
--- set_option leanHoG.proofCheckerCmd "cake_lpr"
 example : ∃ (G : Graph), G.traceable ∧ G.vertexSize > 3 ∧ (G.minimumDegree < G.vertexSize / 2) := by
   find_example
 

--- a/LeanHoG.lean
+++ b/LeanHoG.lean
@@ -1,1 +1,12 @@
+import LeanHoG.Certificate
+import LeanHoG.Edge
+import LeanHoG.Graph
+import LeanHoG.Invariant
+import LeanHoG.JsonData
 import LeanHoG.LoadGraph
+import LeanHoG.Options
+import LeanHoG.Tactic
+import LeanHoG.Util
+import LeanHoG.VertexColoring
+import LeanHoG.Walk
+import LeanHoG.Widgets

--- a/LeanHoG/Invariant.lean
+++ b/LeanHoG/Invariant.lean
@@ -1,0 +1,5 @@
+import LeanHoG.Invariant.Bipartite
+import LeanHoG.Invariant.ConnectedComponents
+import LeanHoG.Invariant.G6
+import LeanHoG.Invariant.HamiltonianPath
+import LeanHoG.Invariant.NeighborhoodMap

--- a/LeanHoG/Invariant/Bipartite.lean
+++ b/LeanHoG/Invariant/Bipartite.lean
@@ -1,0 +1,3 @@
+import LeanHoG.Invariant.Bipartite.Basic
+import LeanHoG.Invariant.Bipartite.Certificate
+import LeanHoG.Invariant.Bipartite.JsonData

--- a/LeanHoG/Invariant/ConnectedComponents.lean
+++ b/LeanHoG/Invariant/ConnectedComponents.lean
@@ -1,0 +1,3 @@
+import LeanHoG.Invariant.ConnectedComponents.Basic
+import LeanHoG.Invariant.ConnectedComponents.Certificate
+import LeanHoG.Invariant.ConnectedComponents.JsonData

--- a/LeanHoG/Invariant/HamiltonianPath.lean
+++ b/LeanHoG/Invariant/HamiltonianPath.lean
@@ -1,0 +1,7 @@
+import LeanHoG.Invariant.HamiltonianPath.Basic
+import LeanHoG.Invariant.HamiltonianPath.Certificate
+import LeanHoG.Invariant.HamiltonianPath.Correctness
+import LeanHoG.Invariant.HamiltonianPath.JsonData
+import LeanHoG.Invariant.HamiltonianPath.SatEncoding
+import LeanHoG.Invariant.HamiltonianPath.SatHelpers
+import LeanHoG.Invariant.HamiltonianPath.Tactic

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -18,7 +18,10 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
   let enc := (hamiltonianPathCNF G).val
   let opts ← getOptions
   let cadicalExe := opts.get leanHoG.solverCmd.name leanHoG.solverCmd.defValue
+  let timeoutSec := opts.get leanHoG.solverTimeout.name leanHoG.solverTimeout.defValue
+  let maxCertMB := opts.get leanHoG.maxCertificateSize.name leanHoG.maxCertificateSize.defValue
   let solver := SolverWithLRAT cadicalExe #["--no-binary", "--lrat=true"]
+    { timeoutSec := timeoutSec, maxProofBytes := maxCertMB * 1024 * 1024 }
   let cnf := Encode.EncCNF.toICnf enc
   let (_, s) := Encode.EncCNF.run enc
   let res ← solver.solve cnf

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -52,9 +52,23 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
     return (existsType, existsHamPath, res)
 
   | .unsat =>
-    -- The formula is UNSAT, add an axiom saying so
+    -- The formula is UNSAT, so we will assert an axiom saying so.
+    --
+    -- Everything that can fail is done *before* `addDecl`. Deriving the
+    -- conclusion from the axiom is the expensive part, and if it is done after
+    -- the axiom is in the environment then running out of heartbeats there
+    -- leaves the axiom behind on a command that reports failure — the user sees
+    -- an error but still has the hole. So the derivation is built against a
+    -- local hypothesis of the axiom's type, and the axiom is only committed
+    -- once that has succeeded.
     let declName : Name := .str graphName "hamiltonianPathCNFUnsat"
     let type : Q(Prop) := q(((hamiltonianPathCNF $graph).val.toICnf.toStd).Unsat)
+    let noExistsType := q(¬ ∃ (u v : Graph.vertex $graph) (p : Path $graph u v), p.isHamiltonian)
+    -- `fun h => no_assignment_implies_no_hamiltonian_path' (std_unsat_implies_no_assignment h)`
+    let derivation ← Meta.withLocalDeclD `hCnfUnsat type fun h => do
+      let noExistsCert ← Meta.mkAppM ``LeanHoG.std_unsat_implies_no_assignment #[h]
+      let noExistsHamPath ← Meta.mkAppM ``LeanHoG.no_assignment_implies_no_hamiltonian_path' #[noExistsCert]
+      Meta.mkLambdaFVars #[h] (← instantiateMVars noExistsHamPath)
     let decl := Declaration.axiomDecl {
       name        := declName,
       levelParams := [],
@@ -63,13 +77,10 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
     }
     trace[Elab.axiom] "{declName} : {type}"
     Term.ensureNoUnassignedMVars decl
+    -- Past this point nothing but `addDecl` itself can fail.
     addDecl decl
     logWarning m!"added axiom {declName} : {type}"
-    let cnfUnsat ← Qq.elabTermEnsuringTypeQ (mkIdent declName) type
-    let noExistsCert ← Meta.mkAppM ``LeanHoG.std_unsat_implies_no_assignment #[cnfUnsat]
-    let noExistsHamPath ← Meta.mkAppM ``LeanHoG.no_assignment_implies_no_hamiltonian_path' #[noExistsCert]
-    let noExistsType := q(¬ ∃ (u v : Graph.vertex $graph) (p : Path $graph u v), p.isHamiltonian)
-    return (noExistsType, noExistsHamPath, res)
+    return (noExistsType, .app derivation (mkConst declName), res)
 
   | .error => throwError "SAT solver exited with error"
 

--- a/LeanHoG/Invariant/NeighborhoodMap.lean
+++ b/LeanHoG/Invariant/NeighborhoodMap.lean
@@ -1,0 +1,3 @@
+import LeanHoG.Invariant.NeighborhoodMap.Basic
+import LeanHoG.Invariant.NeighborhoodMap.Certificate
+import LeanHoG.Invariant.NeighborhoodMap.JsonData

--- a/LeanHoG/LoadGraph.lean
+++ b/LeanHoG/LoadGraph.lean
@@ -209,15 +209,15 @@ unsafe def checkHoGGraphAux (graph : Q(Graph)) (graphName : Name) : Elab.Command
         q(of_decide_eq_true $bipCheck)
         graphName
         "bip"
-        "bipartiteness"
+        "bipartiteness (via a 2-coloring)"
     if let .some (_ : Q(OddClosedWalk $graph)) ← (Elab.Command.liftTermElabM <| Meta.trySynthInstance q(OddClosedWalk $graph) .none) then
       have bipCheck : Q(decide (($rawHoGInstance).bipartite? = .some false) = true) := (q(Eq.refl true) : Lean.Expr)
       tryCheck
         q(($rawHoGInstance).bipartite? = .some false)
         q(of_decide_eq_true $bipCheck)
         graphName
-        "bip"
-        "bipartiteness"
+        "notBip"
+        "bipartiteness (via an odd closed walk)"
 
 /-- This command takes the graph identifier as input. -/
 syntax (name := checkHoGGraph) "check_hog_graph" ident : command

--- a/LeanHoG/Tactic.lean
+++ b/LeanHoG/Tactic.lean
@@ -1,0 +1,4 @@
+import LeanHoG.Tactic.Basic
+import LeanHoG.Tactic.Options
+import LeanHoG.Tactic.ParseExpr
+import LeanHoG.Tactic.SearchDSL

--- a/LeanHoG/Tactic/Options.lean
+++ b/LeanHoG/Tactic/Options.lean
@@ -10,6 +10,21 @@ register_option leanHoG.solverCmd : String := {
   descr := "The location of a solver executable to run the SAT problems"
 }
 
+register_option leanHoG.solverTimeout : Nat := {
+  defValue := 300
+  descr := "Wall-clock limit in seconds for a single SAT solver invocation. \
+            0 disables the limit. Every graph measured so far that the solver \
+            actually decided finished well under 120s."
+}
+
+register_option leanHoG.maxCertificateSize : Nat := {
+  defValue := 1024
+  descr := "Hard cap, in megabytes, on the LRAT certificate a single solver \
+            invocation may write. The solver is killed if it exceeds this. \
+            0 disables the cap, which risks filling the disk: an undecidable \
+            instance can write tens of GB with no natural stopping point."
+}
+
 register_option leanHoG.graphDownloadLocation : String := {
   defValue := "build/graphs"
   descr := "Location for storing downloaded graphs"

--- a/LeanHoG/Util.lean
+++ b/LeanHoG/Util.lean
@@ -1,0 +1,6 @@
+import LeanHoG.Util.LeanSAT
+import LeanHoG.Util.List
+import LeanHoG.Util.PackageDir
+import LeanHoG.Util.Quote
+import LeanHoG.Util.RB
+import LeanHoG.Util.TrestleStd

--- a/LeanHoG/Util/LeanSAT.lean
+++ b/LeanHoG/Util/LeanSAT.lean
@@ -8,6 +8,16 @@ import Std.Tactic.BVDecide.LRAT.Parser
 
 open Trestle
 
+private partial def writeDimacsClauses
+    (stream : IO.FS.Handle) (fml : ICnf) (i : Nat) : IO Unit := do
+  if h : i < fml.size then
+    stream.putStr (Trestle.Solver.Dimacs.formatClause fml[i] ++ "\n")
+    writeDimacsClauses stream fml (i + 1)
+
+private def writeDimacs (stream : IO.FS.Handle) (fml : ICnf) : IO Unit := do
+  stream.putStr s!"p cnf {fml.maxVar} {fml.size}\n"
+  writeDimacsClauses stream fml 0
+
 def runLRATChecker (fml : ICnf) (proof : System.FilePath) : IO Bool :=
   do
     let actions ← Std.Tactic.BVDecide.LRAT.loadLRATProof proof
@@ -16,16 +26,15 @@ def runLRATChecker (fml : ICnf) (proof : System.FilePath) : IO Bool :=
     return Std.Tactic.BVDecide.LRAT.check actions stdCnf
 
 def SolverWithLRAT (solverCmd : String) (solverFlags : Array String := #[]) : Solver IO where
-  solve := fun fml => do
-    let tempFile := "proof.lrat"
+  solve := fun fml => IO.FS.withTempFile fun _ tempFile => do
     let solver ← IO.Process.spawn {
       cmd := solverCmd
-      args := solverFlags ++ #["-", tempFile]
+      args := solverFlags ++ #["-", tempFile.toString]
       stdin := .piped
       stdout := .piped
     }
     let (stdin, solver) ← solver.takeStdin
-    Solver.Dimacs.printICnf (stdin.putStr) fml
+    writeDimacs stdin fml
     stdin.flush
     let output ← IO.asTask solver.stdout.readToEnd Task.Priority.dedicated
 
@@ -33,16 +42,11 @@ def SolverWithLRAT (solverCmd : String) (solverFlags : Array String := #[]) : So
     let outputStr ← IO.ofExcept output.get
     let res ← IO.ofExcept <| Solver.Dimacs.parseResult fml.maxVar outputStr
     match res with
-    | .error =>
-      IO.FS.removeFile tempFile
-      return .error
+    | .error => return .error
     | .unsat =>
       let succeeded ← runLRATChecker fml tempFile
-      IO.FS.removeFile tempFile
       if succeeded then
         return res
       else
         return .error
-    | .sat assn =>
-      IO.FS.removeFile tempFile
-      return (.sat assn)
+    | .sat assn => return (.sat assn)

--- a/LeanHoG/Util/LeanSAT.lean
+++ b/LeanHoG/Util/LeanSAT.lean
@@ -25,20 +25,99 @@ def runLRATChecker (fml : ICnf) (proof : System.FilePath) : IO Bool :=
     let stdCnf := fml.toStd
     return Std.Tactic.BVDecide.LRAT.check actions stdCnf
 
-def SolverWithLRAT (solverCmd : String) (solverFlags : Array String := #[]) : Solver IO where
+/--
+Resource limits for one external solver invocation.
+
+Both matter for different reasons. `timeoutSec` bounds a solver that spins
+without producing much proof; `maxProofBytes` bounds one that produces proof
+very fast. Only the second protects the disk: an undecidable instance can emit
+LRAT at tens of MB/s, so a generous time limit alone still permits many GB.
+-/
+structure SolverLimits where
+  /-- Wall-clock limit in seconds handed to the solver via `-t`. `0` disables. -/
+  timeoutSec : Nat := 300
+  /-- Hard cap on the certificate; the solver is killed past it. `0` disables. -/
+  maxProofBytes : Nat := 1024 * 1024 * 1024
+  deriving Inhabited
+
+/-- Size of `path` in bytes, or `0` if it cannot be stat'd (e.g. not created yet). -/
+private def fileSizeOrZero (path : System.FilePath) : IO Nat := do
+  try
+    return (← path.metadata).byteSize.toNat
+  catch _ =>
+    return 0
+
+/--
+Poll the growing certificate and kill the solver if it passes `maxBytes`.
+
+Returns as soon as `finished` is set, so the caller can join it once the solver
+exits. Sets `tripped` before killing, so the caller can tell "killed by us" from
+"exited on its own".
+-/
+private partial def watchProofSize
+    (killSolver : IO Unit) (proof : System.FilePath) (maxBytes : Nat)
+    (finished tripped : IO.Ref Bool) : IO Unit := do
+  if maxBytes == 0 then return
+  if ← finished.get then return
+  IO.sleep 200
+  if ← finished.get then return
+  if (← fileSizeOrZero proof) > maxBytes then
+    tripped.set true
+    killSolver
+  else
+    watchProofSize killSolver proof maxBytes finished tripped
+
+def SolverWithLRAT (solverCmd : String) (solverFlags : Array String := #[])
+    (limits : SolverLimits := {}) : Solver IO where
   solve := fun fml => IO.FS.withTempFile fun _ tempFile => do
+    let timeoutFlags :=
+      if limits.timeoutSec == 0 then #[] else #["-t", toString limits.timeoutSec]
     let solver ← IO.Process.spawn {
       cmd := solverCmd
-      args := solverFlags ++ #["-", tempFile.toString]
+      args := solverFlags ++ timeoutFlags ++ #["-", tempFile.toString]
       stdin := .piped
       stdout := .piped
     }
     let (stdin, solver) ← solver.takeStdin
     writeDimacs stdin fml
     stdin.flush
+
+    -- Watch the certificate only once the formula is in; nothing is written before that.
+    let finished ← IO.mkRef false
+    let tripped ← IO.mkRef false
+    let watchdog ← IO.asTask
+      (watchProofSize solver.kill tempFile limits.maxProofBytes finished tripped)
+      Task.Priority.dedicated
+
     let output ← IO.asTask solver.stdout.readToEnd Task.Priority.dedicated
 
-    let _ ← solver.wait
+    let exitCode ← solver.wait
+    finished.set true
+    -- Join the watchdog before leaving the temp-file scope, so nothing is still
+    -- stat'ing a path `withTempFile` is about to remove. Its own errors are
+    -- uninteresting: `kill` races the solver exiting on its own.
+    match watchdog.get with
+    | .ok _ => pure ()
+    | .error _ => pure ()
+
+    if ← tripped.get then
+      throw <| IO.userError <|
+        s!"SAT solver killed: its LRAT certificate passed the \
+           {limits.maxProofBytes / (1024 * 1024)} MB cap. This instance is too hard \
+           for the current pipeline; raise `leanHoG.maxCertificateSize` (in MB) to \
+           allow more, or 0 to remove the cap entirely — but note an undecidable \
+           instance will then write until the disk is full."
+
+    -- 10 = SAT, 20 = UNSAT, by SAT-competition convention. Anything else means the
+    -- solver stopped without deciding, which on this path is the `-t` limit. Note
+    -- cadical prints *no* `s` line at all when it times out, so the exit code is
+    -- the only usable signal — do not try to parse the output for this.
+    if exitCode != 10 && exitCode != 20 then
+      throw <| IO.userError <|
+        s!"SAT solver stopped without deciding (exit {exitCode}); it most likely hit \
+           its {limits.timeoutSec}s time limit. Raise `leanHoG.solverTimeout` \
+           (in seconds, 0 for none) to allow more."
+
     let outputStr ← IO.ofExcept output.get
     let res ← IO.ofExcept <| Solver.Dimacs.parseResult fml.maxVar outputStr
     match res with

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,7 +5,10 @@ package «LeanHoG» {
   moreLeanArgs := #["-DautoImplicit=false"]
 }
 
-require «trestle» from git "https://github.com/FormalSAT/trestle.git" @ "853ce03"
+-- Pinned to a commit on trestle's `dev` branch: 4.28 support is not in a
+-- released version yet. Pin, don't track the branch, so builds stay
+-- reproducible. See issue #53 for moving back to a release.
+require «trestle» from git "https://github.com/FormalSAT/trestle.git" @ "853ce034ff4a5081d19ccc250d5780d4b7e718ec"
 
 def widgetDir : FilePath := "widget"
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -63,3 +63,6 @@ target buildWidget pkg : Unit := do
 @[default_target]
 lean_lib LeanHoG where
   needs := #[buildWidget]
+
+lean_lib Examples where
+  needs := #[LeanHoG]

--- a/verifyBatch.py
+++ b/verifyBatch.py
@@ -3,6 +3,8 @@ import os
 import sys
 import subprocess
 import argparse
+import resource
+import time
 
 # File containing a list of ids to verify
 ID_FILE = "graphs.txt"
@@ -61,16 +63,44 @@ def get_ids(listFile):
         ids = map(lambda x : int(x.strip()), lst.readlines())
         return list(ids)
 
-def handleBatch(inputDirName, outputFile, ids, start, stop, reverse):
+def maxRssMiB(usage) -> float:
+    """
+    Peak resident set size of child processes, in MiB.
+
+    `ru_maxrss` is in bytes on macOS and in kilobytes on Linux, so the raw number
+    is off by 1024x between platforms if reported as-is.
+    """
+    if sys.platform == "darwin":
+        return usage.ru_maxrss / (1024 * 1024)
+    return usage.ru_maxrss / 1024
+
+def handleBatch(inputDirName, outputFile, ids, start, stop, reverse) -> bool:
     """
     Verifies the graphs whose ids are in ids at index between start and stop.
+    Returns whether the build succeeded.
     """
     print(f"Doing ids {start} to {stop}.")
     print("    Generating lean file.")
     generateBatch(inputDirName, outputFile, ids, start, stop, reverse)
     print("    Verifying.")
-    subprocess.run(["/usr/bin/time", "--format", "Time %E CPU: User %U Kernel %S Average mem %K Max mem %M", "lake", "build", "verify"])
+    # Timed here rather than by /usr/bin/time: `--format` is GNU coreutils, and
+    # the BSD time on macOS rejects it, so batch timing did not run there at all.
+    before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    wall = time.perf_counter()
+    completed = subprocess.run(["lake", "build", "verify"])
+    wall = time.perf_counter() - wall
+    after = resource.getrusage(resource.RUSAGE_CHILDREN)
+    # `ru_maxrss` is a high-water mark over all children, not an accumulator, so
+    # it is read directly instead of differenced.
+    print(f"Time {wall:.2f}s CPU: User {after.ru_utime - before.ru_utime:.2f} "
+          f"Kernel {after.ru_stime - before.ru_stime:.2f} "
+          f"Max mem {maxRssMiB(after):.1f} MiB")
+    if completed.returncode != 0:
+        # Previously the return code was dropped, so a failed build was recorded
+        # as a completed batch and its timing went into the data as if valid.
+        print(f"    FAILED: lake build verify exited {completed.returncode}.")
     print(f"Done ids {start} to {stop}.")
+    return completed.returncode == 0
 
 def loopCond(start, stop, length, limit, reverse):
     """
@@ -117,7 +147,7 @@ must be present in a directory named graphs. The filename must be <id>.json.
         raise argparse.ArgumentTypeError("batchSize must not be zero.")
     return args
 
-def main():
+def main() -> int:
     args = parse_arguments()
     ids = get_ids(ID_FILE)
     reverse = args.batchSize < 0
@@ -125,10 +155,15 @@ def main():
         args.limit = len(ids) if not reverse else -1
     start = 0 if not reverse else len(ids) - 1
     end = start + args.batchSize
+    failed = 0
     while loopCond(start, end, len(ids), args.limit, reverse):
-        handleBatch(GRAPHS_DIR, VERIFY_LEAN, ids, start, limitedEnd(end, args.limit, reverse), args.batchSize)
+        if not handleBatch(GRAPHS_DIR, VERIFY_LEAN, ids, start, limitedEnd(end, args.limit, reverse), args.batchSize):
+            failed += 1
         start = end
         end = start + args.batchSize
+    if failed:
+        print(f"{failed} batch(es) failed to build; their timings are not valid data.")
+    return 1 if failed else 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Brings `verifyAllGraphs` up to date with `main`, and fixes the things that stop the download path from fetching HoG at all. Base is `verifyAllGraphs`, not `main` — this is to give #50 something current to be decided against, not a request to land the harness.

Six commits, in two groups. Take or drop them individually; they are separable.

**Catching up with `main`** — two merges (the second because 5af17fa landed while this was open) plus one line in `Examples.lean`.

**Fixing the download path** — `treat null and Infinity invariant values as absent`, `skip missing hog ids instead of crashing on them`, `time batches in python, and notice failed builds`, `give the two bipartiteness checks distinct names`. These are in Gauvain's Python and are behaviour changes, not typo fixes, so they are the part worth arguing with.

There is a longer list I did **not** fix, in "Left alone deliberately" below. Those are design questions, and #50 reads better with them stated than silently patched.

## Catching up with `main`

The first merge auto-merged `Examples.lean` and `lakefile.lean` with no conflict; the only judgement call was the trestle pin, where `main`'s full SHA and its comment supersede the abbreviated `853ce03` on this branch:

```
require «trestle» from git "https://github.com/FormalSAT/trestle.git" @ "853ce034ff4a5081d19ccc250d5780d4b7e718ec"
```

Same commit either way — `853ce03` abbreviates it — so nothing about the resolved dependency changes. `lake` warns `manifest out of date: git revision of dependency 'trestle' changed` because the gitignored `lake-manifest.json` still records the short string as `inputRev`; its `rev` already reads `853ce034ff4a5081d19ccc250d5780d4b7e718ec`, and the trestle checkout used for the builds below is that commit. The warning is cosmetic.

This brings in the two SAT/LRAT fixes the branch was missing — 1f6899e (DIMACS streaming stack overflow) and 144705a (build the unsat derivation before asserting the axiom) — plus the solver resource limits from fd1784d.

There is also a one-line cleanup in `Examples.lean`, taking `main`'s value for `leanHoG.pythonExecutable` over the one on this branch.

## Fixing the download path

I went looking for enough graphs to build a `Verify.lean` and could not get them. `Download/invariants.py:27` did `int(value)` unguarded, and HoG serves two things that does not survive: `null` for invariants it has no value for, and the string `"Infinity"` for genuinely infinite ones. It is not consistent about which — graph 300 comes back with diameter `"Infinity"` but radius `null`, and girth `null` despite being acyclic — so both spellings need handling for the same mathematical situation.

Sampling 30 ids: 14 are 404s (HoG ids are not contiguous, which is fine), and of the **16 that exist, 8 downloaded and 8 crashed**. After the fix, all 16 download and nothing raises. Absent invariants are now omitted from the JSON rather than written as null, which needs nothing on the Lean side: every field of `RawHoGData` is already an `Option`, and the derived `FromJson` reads a missing field as `none`. Checked directly on graph 300, which has six absent:

```lean
#eval hog_300.RawHoGI.diameter?          -- none
#eval hog_300.RawHoGI.girth?             -- none
#eval hog_300.RawHoGI.numberOfVertices?  -- some 7
#check hog_300.connComps                 -- still typechecks
```

Note graph **1030** was in the failing set — the 62-vertex, 688,936-clause graph from the DIMACS work. Its JSON demonstrably exists somewhere, and `timings/run-data-gregor.csv` has 2,322 rows, so whatever produced those corpora was not the code in `Download/`. Worth knowing before #50 treats the harness as complete-but-stale.

Three smaller ones alongside it:

- `download_graph` warned on a 404 but neither returned nor raised, so a missing id fell through into invariant parsing and died with `KeyError: '_embedded'`. (A nonexistent id answers 200 on the invariants endpoint with a body holding only `_links`, so the status code alone is not enough to tell.) Missing ids are now a skip with a nonzero exit, not a traceback.
- `Invariants.invariant_values` was a class attribute with a `= {}` default, so one dict was shared by every instance. Harmless for `downloadGraph.py`, which is one graph per process, but it silently writes one graph's invariants into the next graph's JSON for anything that batches — which a bulk downloader for #50 would. This is the one I'd have worried about most: it corrupts rather than crashes.
- `verifyBatch.py` shelled out to `/usr/bin/time --format`, which is GNU coreutils; the BSD `time` on macOS rejects it (`illegal option -- -`), so batch timing did not run there at all. Now timed in Python via `perf_counter` and `getrusage`, normalising `ru_maxrss` (bytes on macOS, kilobytes on Linux). It also ignored `subprocess.run`'s return code, so a failed `lake build verify` was recorded as a completed batch with valid-looking timings; it now reports the failure and exits nonzero.

And one latent Lean-side fix: both bipartiteness branches in `checkHoGGraphAux` emitted the same `bip` decl name, so a JSON carrying both a `twoColoring` and an `oddClosedWalk` would fail the second `addAndCompile`, get swallowed by `tryCheck`'s `catch`, and report a spurious `Error when checking bipartiteness`. Unreachable today — no graph is both bipartite and has an odd closed walk, and the downloader emits neither certificate — so drop this commit if you would rather not rename a decl for a bug that cannot fire.

## What this does not fix

I merged expecting the fixes to unbreak verification past ~13 vertices. They don't, because **the harness on this branch never reaches the SAT path at all.**

`check_hog_graph` (`LeanHoG/LoadGraph.lean`, `checkHoGGraphAux`) emits at most three checks: connected components, and bipartiteness via either a `TwoColoring` or an `OddClosedWalk` instance. `Graph.checkHoGtraceable` exists in `RawHoG.lean` but is called from nowhere — the single reference in the tree is `Examples.lean:88`, commented out.

On the JSON the downloader actually produces, only *one* of the three fires. `Download/jsonEncoder.py`'s `GraphEncoder` emits `connectedComponents`, `neighborhoodMap`, `rawHoG` and `canonicalForm` — no `twoColoring`, `oddClosedWalk` or `hamiltonianPath`. So after `check_hog_graph hog_1000`:

```
#check hog_1000.connComps   -- (hog_1000.RawHoGI.toRawHoGData hog_1000).numberOfComponents? = some (ConnectedComponents.val hog_1000)
#check hog_1000.bip         -- error: The environment does not contain `LeanHoG.Graph.bip`
```

`lake build verify` therefore verifies exactly one invariant per graph, the number of connected components. Two checks confirm no solver is involved:

- `lake build verify` succeeds with `cadical` removed from `PATH`.
- `LeanHoG/Util/LeanSAT.lean` is imported only by `LeanHoG/Invariant/HamiltonianPath/Tactic.lean`, which is outside `LoadGraph.lean`'s import closure. Forcing a full rebuild of `Verify` on *unmerged* `origin/verifyAllGraphs` also succeeds, in 9.5s.

That last point is the one that matters for #50. `lake build verify` — the command `verifyBatch.py` times, and so the one any benchmark runs — gives the same numbers before and after this merge, because it does not compile the files the merge changed. What it times is connected-components certificate checking plus `load_graph` elaboration.

To be clear about what 5af17fa changed: `lake build Examples` *does* now compile `Tactic.lean` and `LeanSAT.lean`, and running it does exercise the solver. So #47's false-green problem is addressed for `Examples`. It just is not the target the benchmark uses, and `check_hog_graph` still has no path to `checkHoGtraceable` regardless of which target builds it.

## Left alone deliberately

These are the ones I think are yours or Gauvain's to decide, not mine to patch under cover of a merge.

**`load_graph`'s `try_ham` is dead syntax.** Declared in the `syntax` command at `LoadGraph.lean:36`, but `loadGraphImpl` matches only `load_graph $graphName $fileName`, so `load_graph G "f" try_ham` gives `unexpected syntax`. Given the section above, this looks like the vestige of the intended design: `try_ham` would have been where a `HamiltonianPath` instance got built, which is exactly the missing link between `check_hog_graph` and `checkHoGtraceable`. Worth asking Gauvain what it was for before deciding to redo the branch — it may be that the design is right and only this hook is unfinished.

**Two parallel implementations of "check a HoG invariant".** `RawHoG.lean` has six `Graph.checkHoG*` functions returning `Bool`; `checkHoGGraphAux` calls none of them, rebuilding the propositions inline and discharging them with `of_decide_eq_true`. That is the better path — a typechecked proof term rather than a `Bool` — but it leaves the six reachable only from the `#eval` demos at `Examples.lean:82-88`. One of the two should probably go, and deleting the `Bool` ones means editing those demos, which are currently the only illustration that any of this works. A call for you rather than a cleanup.

**41 of the 42 `RawHoGData` fields have no certificate producer.** Not a bug — this is #51, and it is the actual roadmap.

**Whether "HoG says infinity" should be representable.** I made `"Infinity"` absent, which is the minimal thing that unblocks downloading and costs nothing today because nothing verifies diameter or radius. If those get certificates later, absent and infinite will need distinguishing, and that is a schema decision.

## Verification

On the tip commit, with `cadical` on `PATH` and `python` 3.12.9 with `requests`. Graphs fetched fresh with the fixed downloader — ids 194, 226, 300, 450, 660, 1000, 1030, 1300, 3000, 8000, plus 6 and 1500 to exercise the missing-id path; sizes 5 to 62 vertices, well past the ~13 threshold from #54.

- Downloader over those 12 ids: `downloaded=10 skipped=2 tracebacks=0`. On `origin/verifyAllGraphs`, 194/300/1030/1300/3000/8000 abort and 6/1500 give `KeyError`.
- `lake build` — `Build completed successfully (3256 jobs)`.
- `python Verify/generateVerifyLean.py <dir> -o Verify.lean`, then `lake build verify` — `Built Verify`, `Build completed successfully (3256 jobs)`, with `Verify.olean` deleted first.
- `lake build Examples`, main's target from 5af17fa — `Build completed successfully (3279 jobs)`, reaching `Closed goal using hog_194` and the `added axiom hog_896.hamiltonianPathCNFUnsat` warning, so the SAT path does compile and run after the merge.
- `verifyBatch.py 5` over the 10 graphs, on macOS, which previously could not run it at all:

  ```
  Time 11.51s CPU: User 2.19 Kernel 2.56 Max mem 2992.0 MiB
  Time 3.69s CPU: User 2.51 Kernel 1.86 Max mem 3084.8 MiB
  ```

  And with a deliberately bad id in `graphs.txt` it prints `FAILED: lake build verify exited 1` and exits 1, where before it exited 0.

So the branch does build on 4.28; Lean-side, your three commits got it there.

## The `lean_lib Examples` conflict, already resolved here

5af17fa landed on `main` while this was open, adding `lean_lib Examples` at the bottom of `lakefile.lean` — the same block this branch appends `lean_lib verify` to. That conflicted, and the second merge commit here resolves it by keeping both, `Examples` in the position 5af17fa put it:

```lean
lean_lib Examples where
  needs := #[LeanHoG]

-- This is only to get the command "lake build verify" to build Verify.lean
-- This way, there is no need to open the file in an editor.
lean_lib verify where
  srcDir := "."
  roots := #[`Verify]
```

The two targets are complementary, not redundant. `Examples` compiles `Tactic.lean` and `LeanSAT.lean` — the code `verify` does not reach, per the section above. `verify` builds the generated `Verify.lean`, which `Examples` knows nothing about.

One consistency note, not changed here: `verify` has no `needs`, where 5af17fa gives `Examples` `needs := #[LeanHoG]`. `verify` does not actually need one — it already pulls in `buildWidget` transitively by importing `LeanHoG.LoadGraph`, which belongs to `lean_lib LeanHoG` (checked by hiding `build/js/` and forcing a rebuild: lake reports `✖ Building LeanHoG/buildWidget — target is out-of-date`). Adding `needs := #[LeanHoG]` for symmetry would be reasonable but is a style call on someone else's stanza, so I left it alone.

## Caveats

Not hermetic, and inherited: needs `cadical` on `PATH` (for `lake build`'s sake, though `verify` turns out not to use it), Python with `requests`, and network access to HoG. There is still no CI, so nothing reruns this — I verified by hand on macOS 26.5.2 / arm64, one platform only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


*— Claude (Claude Code), posting from @lucyhorowitz's account*
