### PR TITLE
Make the check_traceable tactic work on traceable graphs too

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -99,19 +99,27 @@ load_graph hog_896 "build/graphs/896.json"
 #show_hamiltonian_path hog_896
 
 -- The command only reports what it found. To use the result in a proof there is
--- a tactic of the same name, without the leading `#`. The tactic does not need
--- the command to have been run on the graph first: each example below uses a
--- graph that no `#check_traceable` above has touched.
+-- a tactic of the same name, without the leading `#`. It decides traceability in
+-- both directions, so it proves that a graph *is* traceable just as well as that
+-- it is not.
 
--- `check_traceable` adds the fact it derives to the context as a hypothesis. It
--- does not close the goal, and the hypothesis is the unfolded existential rather
--- than `¬ G.traceable`, so the proof is finished with `assumption`.
+-- `check_traceable` adds the fact it derives to the context as a hypothesis; it
+-- does not close the goal, so the proof is finished with `assumption`.
 #download Fork 30
 example : ¬Fork.traceable := by
   check_traceable Fork
   assumption
 
--- `with h` gives that hypothesis a name instead of leaving it inaccessible.
+-- The same tactic on a goal of the opposite sign. Here the solver returns a
+-- satisfying assignment, which is read back as an actual Hamiltonian path, so the
+-- hypothesis is `Petersen.traceable` and the proof depends on no axiom.
+example : Petersen.traceable := by
+  check_traceable Petersen
+  assumption
+
+-- `with h` gives that hypothesis a name instead of leaving it inaccessible. In the
+-- UNSAT case the hypothesis is the unfolded existential rather than `¬ G.traceable`,
+-- which is why `assumption` above is the finisher to reach for in general.
 #download HGraph 334
 example : ¬HGraph.traceable := by
   check_traceable HGraph with h
@@ -122,6 +130,11 @@ example : ¬HGraph.traceable := by
 #download Cross 208
 example : ¬Cross.traceable := by
   check_traceablea Cross
+
+-- `#check_traceable Wheel` above already registered a Hamiltonian path for `Wheel`.
+-- The tactic reuses that certificate rather than clashing with it.
+example : Wheel.traceable := by
+  check_traceablea Wheel
 
 ---------------------------------------
 -- Tactics

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -38,16 +38,25 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
     let hpQ := hamiltonianPathOfData graph ⟨path.toList⟩
     -- Add a Hamiltonian path instance from the constructed path
     let hamiltonianPathName := certificateName graphName "HamiltonianPathI"
-    Lean.addAndCompile <| .defnDecl {
-      name := hamiltonianPathName
-      levelParams := []
-      type := q(HamiltonianPath $graph)
-      value := hpQ
-      hints := .regular 0
-      safety := .safe
-    }
-    Lean.Meta.addInstance hamiltonianPathName .global 42
-    let existsHamPath ← Meta.mkAppM ``LeanHoG.HamiltonianPath.path_of_cert #[]
+    -- The name is a function of the graph's, so a second run on the same graph —
+    -- `#check_traceable G` and then the tactic, or the tactic twice — would be
+    -- re-declaring it. The certificate already in the environment is a certificate
+    -- for the same graph, so reuse it rather than failing.
+    unless (← getEnv).contains hamiltonianPathName do
+      Lean.addAndCompile <| .defnDecl {
+        name := hamiltonianPathName
+        levelParams := []
+        type := q(HamiltonianPath $graph)
+        value := hpQ
+        hints := .regular 0
+        safety := .safe
+      }
+      Lean.Meta.addInstance hamiltonianPathName .global 42
+    -- Applied to the certificate by name, not left to instance synthesis: `mkAppM`
+    -- with no arguments returns the bare constant, whose implicit `G` and instance
+    -- are still abstracted, and that only fails later in the kernel.
+    let existsHamPath ← Meta.mkAppOptM ``LeanHoG.HamiltonianPath.path_of_cert
+      #[graph, mkConst hamiltonianPathName]
     let existsType := q(Graph.traceable $graph)
     return (existsType, existsHamPath, res)
 
@@ -91,23 +100,28 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
 
 syntax (name := checkTraceable) "#check_traceable " ident : command
 /-- `#check_traceable G` runs a SAT solver on the encoding of the Hamiltonian path problem
-    on the graph `G`. If the SAT solver says the problem is unsatisfiable, Lean's built-in
-    verified LRAT checker checks the produced proof. If the checker accepts it, we add an axiom
-    saying there is no satisfying assignment for the encoding.
+    on the graph `G`. It decides traceability either way:
 
-    This is the *command* form: it reports what it found and, when there is a Hamiltonian
-    path, registers it as an instance. It proves nothing about the current goal — see the
-    `check_traceable` tactic for that. The two are independent: the tactic does not require
-    the command to have been run on `G` first.
+    * **SAT.** The satisfying assignment is read back as a Hamiltonian path and registered
+      as a `HamiltonianPath G` instance, which `#show_hamiltonian_path G` will then print.
+    * **UNSAT.** Lean's built-in verified LRAT checker checks the produced proof. If the
+      checker accepts it, we add an axiom saying there is no satisfying assignment for the
+      encoding.
+
+    This is the *command* form: it reports what it found. It proves nothing about the
+    current goal — see the `check_traceable` tactic for that. The two are independent: the
+    tactic does not require the command to have been run on `G` first.
 -/
 @[command_elab checkTraceable]
 unsafe def checkTraceableImpl : Command.CommandElab
   | `(#check_traceable $g) => Command.liftTermElabM do
     let graphName := g.getId
     let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
-    let (declName, _, res) ← searchForHamiltonianPathAux graphName graph
+    let (_, _, res) ← searchForHamiltonianPathAux graphName graph
     match res with
-    | .sat _ => logInfo m!"found Hamiltonian path {declName}"
+    | .sat _ =>
+      logInfo m!"found Hamiltonian path, registered as \
+        {certificateName graphName "HamiltonianPathI"}"
     | .unsat => logInfo m!"no Hamiltonian path found after exhaustive search"
     | .error => throwError "SAT solver exited with error"
 
@@ -119,7 +133,8 @@ unsafe def checkTraceableImpl : Command.CommandElab
 
 open Trestle Model in
 /-- Run the Hamiltonian path search on `g` and add what it establishes to the local
-    context as a hypothesis named `h`. Shared by the `check_traceable` and
+    context as a hypothesis named `h` — `g.traceable` if the solver found a path, the
+    negated existential if it proved there is none. Shared by the `check_traceable` and
     `check_traceablea` tactics.
 -/
 unsafe def assertTraceabilityFact (g : Ident) (h : Name) : Tactic.TacticM Unit :=
@@ -133,21 +148,34 @@ unsafe def assertTraceabilityFact (g : Ident) (h : Name) : Tactic.TacticM Unit :
 
 syntax (name := checkTraceableTactic) "check_traceable " ident (" with" (ppSpace colGt ident))? : tactic
 /-- `check_traceable G` runs a SAT solver on the encoding of the Hamiltonian path problem
-    on the graph `G`. If the SAT solver says the problem is unsatisfiable, Lean's built-in
-    verified LRAT checker checks the produced proof. If the checker accepts it, we add an axiom
-    saying there is no satisfying assignment for the encoding. The tactic uses the new axiom and
-    the encoding correctness theorem to deduce that there is no Hamiltonian path in the graph,
-    then adds that result as a hypothesis to the current context.
+    on the graph `G` and adds what the solver decided to the local context as a hypothesis.
+    It is a decider, not a refuter: it serves goals of both signs, and you do not have to
+    know which way the answer goes before invoking it.
 
-    **This tactic adds a hypothesis; it does not close the goal.** The hypothesis is the
-    unfolded existential, not `¬ G.traceable`, so finish with `assumption` (or use
-    `check_traceablea`, which does that for you):
+    * **SAT.** The satisfying assignment is read back as a Hamiltonian path, and the
+      hypothesis is `G.traceable`. The proof is the path itself — no axiom is involved.
+    * **UNSAT.** Lean's built-in verified LRAT checker checks the produced proof. If the
+      checker accepts it, we add an axiom saying there is no satisfying assignment for the
+      encoding, and use it together with the encoding correctness theorem to derive the
+      hypothesis `¬ ∃ u v (p : Path G u v), p.isHamiltonian`.
+
+    **This tactic adds a hypothesis; it does not close the goal.** Finish with `assumption`,
+    or use `check_traceablea`, which does that for you:
 
     ```lean
+    example : Wheel.traceable := by
+      check_traceable Wheel
+      assumption
+
     example : ¬hog_896.traceable := by
       check_traceable hog_896
       assumption
     ```
+
+    Note the asymmetry between the two hypotheses. In the SAT case it is `G.traceable`
+    on the nose; in the UNSAT case it is the *unfolded* existential rather than
+    `¬ G.traceable`, which is why `assumption` — and not `exact` against the goal as
+    stated — is the right finisher in general.
 
     `check_traceable G with h` names the hypothesis `h` instead of leaving it inaccessible:
 
@@ -158,7 +186,7 @@ syntax (name := checkTraceableTactic) "check_traceable " ident (" with" (ppSpace
     ```
 
     The tactic is self-contained — it does not require `#check_traceable G` to have been
-    run on `G` beforehand.
+    run on `G` beforehand, and does not conflict with it if it has.
 -/
 @[tactic checkTraceableTactic]
 unsafe def checkTraceableTacticImpl : Tactic.Tactic
@@ -169,9 +197,13 @@ unsafe def checkTraceableTacticImpl : Tactic.Tactic
 syntax (name := checkTraceableaTactic) "check_traceablea " ident : tactic
 /-- `check_traceablea G` is `check_traceable G` followed by `assumption`, in the same spirit
     as `simpa` for `simp`: it derives the fact about Hamiltonian paths in `G` and then uses
-    it to close the goal, rather than leaving it in the context.
+    it to close the goal, rather than leaving it in the context. Like `check_traceable`, it
+    decides traceability in both directions:
 
     ```lean
+    example : Wheel.traceable := by
+      check_traceablea Wheel
+
     example : ¬hog_896.traceable := by
       check_traceablea hog_896
     ```

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -11,6 +11,28 @@ namespace LeanHoG
 
 open Lean Elab Qq
 
+/-- Whether `declName` already holds a declaration of type `expectedType`, which a
+    previous run on the same graph would have left there and which can therefore be
+    reused instead of declared again.
+
+    The name existing is not on its own evidence that it holds such a declaration: the
+    names below are derived from the graph's, and nothing stops anything else in the
+    environment from having claimed one first. Reusing whatever is there would build a
+    term against the wrong type and only fail later, in the kernel, complaining about a
+    term the user never wrote. So a name held by something of another type is reported
+    here instead; the name is taken either way, and there is nothing useful to do but
+    say so.
+
+    The comparison runs at a new metavariable depth so that a mismatch cannot leave
+    `expectedType`'s metavariables assigned behind it. -/
+private def hasReusableDecl (declName : Name) (expectedType : Expr) : Meta.MetaM Bool := do
+  let some info := (← getEnv).find? declName | return false
+  if ← Meta.withNewMCtxDepth (Meta.isDefEq info.type (← instantiateMVars expectedType)) then
+    return true
+  else
+    throwError "the name {declName} is already taken by a declaration of type\
+      {indentExpr info.type}\nbut this graph needs one of type{indentExpr expectedType}"
+
 open Trestle Model in
 /-- Decide traceability of `graph` with the SAT solver, and return the fact that
     establishes, a proof of it, and the solver's answer.
@@ -59,17 +81,19 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph))
     --
     -- The name is a function of the graph's, so a second run on the same graph —
     -- `#check_traceable G` and then the tactic, or the tactic twice — would be
-    -- re-declaring it. The certificate already in the environment is a certificate
-    -- for the same graph, so reuse it rather than failing.
+    -- re-declaring it. A `HamiltonianPath $graph` already in the environment is a
+    -- certificate for the same graph, so reuse it rather than failing; that it is one,
+    -- and not merely something sitting on the name, is what `hasReusableDecl` checks.
     let hamiltonianPathName := certificateName graphName "HamiltonianPathI"
+    let certType : Q(Type) := q(HamiltonianPath $graph)
     let cert : Expr ←
-      if (← getEnv).contains hamiltonianPathName then
+      if ← hasReusableDecl hamiltonianPathName certType then
         pure (mkConst hamiltonianPathName)
       else if register then do
         Lean.addAndCompile <| .defnDecl {
           name := hamiltonianPathName
           levelParams := []
-          type := q(HamiltonianPath $graph)
+          type := certType
           value := hpQ
           hints := .regular 0
           safety := .safe
@@ -100,12 +124,13 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph))
     let type : Q(Prop) := q(((hamiltonianPathCNF $graph).val.toICnf.toStd).Unsat)
     let noExistsType := q(¬ ∃ (u v : Graph.vertex $graph) (p : Path $graph u v), p.isHamiltonian)
     -- Where the axiom goes. One for this graph already in the environment says
-    -- exactly what is needed, so reuse it; that is the case a second run on the
+    -- exactly what is needed — literally so, which is what `hasReusableDecl` confirms
+    -- before we lean on it — so reuse it; that is the case a second run on the
     -- same graph used to die on. Otherwise declare it, globally for the command and
     -- beneath the enclosing declaration for a tactic, which may not add a name
     -- outside its own prefix.
     let declName : Name ←
-      if (← getEnv).contains globalName ∨ register then
+      if (← hasReusableDecl globalName type) ∨ register then
         pure globalName
       else
         match ← Term.getDeclName? with
@@ -116,7 +141,7 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph))
       let noExistsCert ← Meta.mkAppM ``LeanHoG.std_unsat_implies_no_assignment #[h]
       let noExistsHamPath ← Meta.mkAppM ``LeanHoG.no_assignment_implies_no_hamiltonian_path' #[noExistsCert]
       Meta.mkLambdaFVars #[h] (← instantiateMVars noExistsHamPath)
-    unless (← getEnv).contains declName do
+    unless ← hasReusableDecl declName type do
       let decl := Declaration.axiomDecl {
         name        := declName,
         levelParams := [],

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -12,8 +12,25 @@ namespace LeanHoG
 open Lean Elab Qq
 
 open Trestle Model in
-unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
-  TermElabM (Expr × Expr × Solver.Res) := do
+/-- Decide traceability of `graph` with the SAT solver, and return the fact that
+    establishes, a proof of it, and the solver's answer.
+
+    `register` says whether that fact should be backed by a declaration named after
+    the *graph*: the `HamiltonianPath` instance in the SAT case, the axiom in the
+    UNSAT case. The `#check_traceable` command wants one, since registering a
+    reusable certificate is the whole point of the command and
+    `#show_hamiltonian_path` looks the instance up by name.
+
+    The `check_traceable` tactics must not ask for one. Lean elaborates declarations
+    in parallel and lets each add only names beneath its own prefix, so a named
+    theorem cannot introduce `G.HamiltonianPathI` and fails with `cannot add
+    declaration ... as it is restricted to the prefix ...`. With
+    `register := false` the certificate is placed in the proof term directly, and
+    the axiom — which has to be a declaration, there being no other way to assert
+    one — is named beneath the declaration being elaborated. Either way an
+    equivalent declaration already in the environment is reused. -/
+unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph))
+    (register : Bool) : TermElabM (Expr × Expr × Solver.Res) := do
   let G ← Meta.evalExpr' Graph ``Graph graph
   let enc := (hamiltonianPathCNF G).val
   let opts ← getOptions
@@ -36,27 +53,36 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
         | some (_, true) => path := path.set! j i
         | some (_, false) => continue
     let hpQ := hamiltonianPathOfData graph ⟨path.toList⟩
-    -- Add a Hamiltonian path instance from the constructed path
-    let hamiltonianPathName := certificateName graphName "HamiltonianPathI"
+    -- The certificate to hand to `path_of_cert`. `hamiltonianPathOfData` returns a
+    -- self-contained term, so a declaration is a convenience and never a necessity:
+    -- it makes the certificate reusable and visible to instance synthesis.
+    --
     -- The name is a function of the graph's, so a second run on the same graph —
     -- `#check_traceable G` and then the tactic, or the tactic twice — would be
     -- re-declaring it. The certificate already in the environment is a certificate
     -- for the same graph, so reuse it rather than failing.
-    unless (← getEnv).contains hamiltonianPathName do
-      Lean.addAndCompile <| .defnDecl {
-        name := hamiltonianPathName
-        levelParams := []
-        type := q(HamiltonianPath $graph)
-        value := hpQ
-        hints := .regular 0
-        safety := .safe
-      }
-      Lean.Meta.addInstance hamiltonianPathName .global 42
-    -- Applied to the certificate by name, not left to instance synthesis: `mkAppM`
+    let hamiltonianPathName := certificateName graphName "HamiltonianPathI"
+    let cert : Expr ←
+      if (← getEnv).contains hamiltonianPathName then
+        pure (mkConst hamiltonianPathName)
+      else if register then do
+        Lean.addAndCompile <| .defnDecl {
+          name := hamiltonianPathName
+          levelParams := []
+          type := q(HamiltonianPath $graph)
+          value := hpQ
+          hints := .regular 0
+          safety := .safe
+        }
+        Lean.Meta.addInstance hamiltonianPathName .global 42
+        pure (mkConst hamiltonianPathName)
+      else
+        pure hpQ
+    -- Applied to the certificate explicitly, not left to instance synthesis: `mkAppM`
     -- with no arguments returns the bare constant, whose implicit `G` and instance
     -- are still abstracted, and that only fails later in the kernel.
     let existsHamPath ← Meta.mkAppOptM ``LeanHoG.HamiltonianPath.path_of_cert
-      #[graph, mkConst hamiltonianPathName]
+      #[graph, cert]
     let existsType := q(Graph.traceable $graph)
     return (existsType, existsHamPath, res)
 
@@ -70,25 +96,38 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph)) :
     -- an error but still has the hole. So the derivation is built against a
     -- local hypothesis of the axiom's type, and the axiom is only committed
     -- once that has succeeded.
-    let declName : Name := .str graphName "hamiltonianPathCNFUnsat"
+    let globalName : Name := .str graphName "hamiltonianPathCNFUnsat"
     let type : Q(Prop) := q(((hamiltonianPathCNF $graph).val.toICnf.toStd).Unsat)
     let noExistsType := q(¬ ∃ (u v : Graph.vertex $graph) (p : Path $graph u v), p.isHamiltonian)
+    -- Where the axiom goes. One for this graph already in the environment says
+    -- exactly what is needed, so reuse it; that is the case a second run on the
+    -- same graph used to die on. Otherwise declare it, globally for the command and
+    -- beneath the enclosing declaration for a tactic, which may not add a name
+    -- outside its own prefix.
+    let declName : Name ←
+      if (← getEnv).contains globalName ∨ register then
+        pure globalName
+      else
+        match ← Term.getDeclName? with
+        | some enclosing => pure (enclosing ++ globalName)
+        | none => pure globalName
     -- `fun h => no_assignment_implies_no_hamiltonian_path' (std_unsat_implies_no_assignment h)`
     let derivation ← Meta.withLocalDeclD `hCnfUnsat type fun h => do
       let noExistsCert ← Meta.mkAppM ``LeanHoG.std_unsat_implies_no_assignment #[h]
       let noExistsHamPath ← Meta.mkAppM ``LeanHoG.no_assignment_implies_no_hamiltonian_path' #[noExistsCert]
       Meta.mkLambdaFVars #[h] (← instantiateMVars noExistsHamPath)
-    let decl := Declaration.axiomDecl {
-      name        := declName,
-      levelParams := [],
-      type        := type,
-      isUnsafe    := false
-    }
-    trace[Elab.axiom] "{declName} : {type}"
-    Term.ensureNoUnassignedMVars decl
-    -- Past this point nothing but `addDecl` itself can fail.
-    addDecl decl
-    logWarning m!"added axiom {declName} : {type}"
+    unless (← getEnv).contains declName do
+      let decl := Declaration.axiomDecl {
+        name        := declName,
+        levelParams := [],
+        type        := type,
+        isUnsafe    := false
+      }
+      trace[Elab.axiom] "{declName} : {type}"
+      Term.ensureNoUnassignedMVars decl
+      -- Past this point nothing but `addDecl` itself can fail.
+      addDecl decl
+      logWarning m!"added axiom {declName} : {type}"
     return (noExistsType, .app derivation (mkConst declName), res)
 
   | .error => throwError "SAT solver exited with error"
@@ -117,7 +156,7 @@ unsafe def checkTraceableImpl : Command.CommandElab
   | `(#check_traceable $g) => Command.liftTermElabM do
     let graphName := g.getId
     let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
-    let (_, _, res) ← searchForHamiltonianPathAux graphName graph
+    let (_, _, res) ← searchForHamiltonianPathAux graphName graph (register := true)
     match res with
     | .sat _ =>
       logInfo m!"found Hamiltonian path, registered as \
@@ -140,7 +179,7 @@ open Trestle Model in
 unsafe def assertTraceabilityFact (g : Ident) (h : Name) : Tactic.TacticM Unit :=
   Tactic.withMainContext do
     let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
-    let (type, proof, _) ← searchForHamiltonianPathAux g.getId graph
+    let (type, proof, _) ← searchForHamiltonianPathAux g.getId graph (register := false)
     Tactic.liftMetaTactic fun mvarId => do
       let mvarIdNew ← mvarId.assert h type proof
       let (_, mvarIdNew) ← mvarIdNew.intro1P

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -74,6 +74,32 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph))
         | none => throwError "invalid index ({i},{j})"
         | some (_, true) => path := path.set! j i
         | some (_, false) => continue
+    -- The assignment is the solver's word for it, so check that it really describes
+    -- a Hamiltonian path before building a certificate out of it.
+    --
+    -- Soundness does not rest on this check. `hamiltonianPathOfData` proves every
+    -- step by `Eq.refl` at `decide` — one adjacency, then `Walk.isPath`, then
+    -- `Path.isHamiltonian` — so a bogus path cannot be accepted. But it is the
+    -- *kernel* that rejects it, as an `of_decide_eq_true` type mismatch that says
+    -- nothing about a solver, and the kernel check is deferred, so the command gets
+    -- as far as reporting that it registered a certificate first. Checking here
+    -- reports what actually went wrong, and stops before anything claims success.
+    let vs := path.toList
+    let solverBlame := m!"The solver named by `leanHoG.solverCmd` ({cadicalExe}) is \
+      not answering correctly."
+    if vs.mergeSort (· ≤ ·) ≠ List.range G.vertexSize then
+      throwError "the SAT solver returned an assignment that does not describe a \
+        Hamiltonian path in {graphName}: {toString vs} is not a permutation of the \
+        {G.vertexSize} vertices. {solverBlame}"
+    for uv in vs.zip vs.tail do
+      let (u, v) := uv
+      if hu : u < G.vertexSize then
+        if hv : v < G.vertexSize then
+          unless G.badjacent ⟨u, hu⟩ ⟨v, hv⟩ do
+            throwError "the SAT solver returned an assignment that does not describe \
+              a Hamiltonian path in {graphName}: {u} and {v} are consecutive on the \
+              returned path {toString vs}, but are not adjacent in the graph. \
+              {solverBlame}"
     let hpQ := hamiltonianPathOfData graph ⟨path.toList⟩
     -- The certificate to hand to `path_of_cert`. `hamiltonianPathOfData` returns a
     -- self-contained term, so a declaration is a convenience and never a necessity:

--- a/LeanHoG/Tactic/Basic.lean
+++ b/LeanHoG/Tactic/Basic.lean
@@ -113,7 +113,11 @@ unsafe def findExampleImpl : Tactic.Tactic
                 -- Now try to simp which will among other things look for instance for e.g. HamiltonianPath
                 if mentionsTracability then
                   -- If we want to prove things about tracability we need to search for a Hamiltonian path
+                  -- `register := true`: the SAT case below closes the goal by instance
+                  -- synthesis rather than with the proof term, so the certificate has
+                  -- to be a registered instance and not just a term.
                   let (val, type, res) ← LeanHoG.searchForHamiltonianPathAux graphIdent.getId r
+                    (register := true)
                   match res with
                   | .unsat =>
                     Tactic.liftMetaTactic fun mvarId => do


### PR DESCRIPTION
The SAT direction of the `check_traceable` tactic never worked. Two independent faults, both surfacing only in the kernel, so neither was visible from the tactic's own error reporting. Fixing them exposed a third, which they had been hiding.

**The hypothesis was never applied to anything.** `mkAppM ``HamiltonianPath.path_of_cert #[]` with an empty argument array returns the bare constant, whose implicit `G` and `HamiltonianPath G` instance are still abstracted. On `main`, `example : Petersen.traceable := by check_traceable Petersen; assumption` gives:

```
error: (kernel) declaration type mismatch, 'LeanHoG._example' has type
  ∀ {G : Graph} [hp : HamiltonianPath G], G.traceable
but it is expected to have type
  Graph.traceable P
```

It is now applied to the certificate by name with `mkAppOptM`.

**A second run on the same graph collided.** The certificate's name is a function of the graph's, so `#check_traceable G` followed by the tactic on `G` — or the tactic twice — tried to re-declare it. On `main`:

```
error: (kernel) constant has already been declared 'W.HamiltonianPathI'
```

The certificate already in the environment is a certificate for the same graph, so it is reused rather than re-added.

**Neither direction could create its declaration inside a named theorem.** Both tactics add a declaration named after the graph: the `HamiltonianPath` instance in the SAT case, the unsat axiom in the UNSAT case. Lean elaborates declarations in parallel and lets each add only names beneath its own prefix, so a named theorem that has to create one gets:

```
error: cannot add declaration P.HamiltonianPathI to environment
       as it is restricted to the prefix pt
```

Anonymous `example`s are exempt, which is why nothing in `Examples.lean` trips over this, and why it only became visible once the two faults above were out of the way. `searchForHamiltonianPathAux` now takes `register`, separating "make a reusable global declaration", which is what the command is for, from "prove this goal", which is all a tactic needs:

- SAT with `register := false`: `hamiltonianPathOfData` already returns a self-contained term, so the certificate goes straight into the proof term and nothing is added to the environment at all.
- UNSAT with `register := false`: an axiom has to be a declaration, there being no other way to assert one, so it is named beneath the declaration being elaborated, where the restriction allows it.
- Both now reuse an equivalent declaration already in the environment. The SAT branch already did; the UNSAT branch did not, so the command followed by the tactic on the same graph died with `constant has already been declared`. That is the workaround suggested in #64, which therefore only ever covered the SAT half.

`find_example` keeps `register := true`: its SAT case closes the goal by instance synthesis rather than with the returned proof term, so there the certificate does have to be a registered instance. Closes #64. Closes #63 too: its fix, #69, merged into this branch rather than `main`, so that PR's own keyword never fired and only this merge can close it.

One consequence worth stating: a tactic no longer leaves a certificate behind, so `#show_hamiltonian_path G` after a tactic-only use of `G` reports nothing. That was already true of a use inside an `example`, whose declarations do not persist, so this makes the two consistent rather than taking anything away from the command.

Also in here: the command reported `found Hamiltonian path W.traceable`, naming the *type* of the fact rather than the declaration it registered, so it now names `W.HamiltonianPathI`; and the docstrings now say that both tactics decide traceability either way, with an example of each direction, since that was the part the previous docs left out.

Testing, with real cadical:

- the command then the tactic on the same graph now works, where `main` dies with "constant has already been declared"
- the tactic on a graph no command has touched proves `P.traceable`, where `main` dies with the declaration type mismatch above, and works a second time on the same graph
- a named `theorem` now works in both directions with nothing registered beforehand, and twice on the same graph; `main` and the first two fixes alone both die with the prefix restriction
- the command then a named `theorem` works in both directions; before this the UNSAT half of that died with "constant has already been declared"
- `#print axioms` on a SAT-direction theorem lists only `propext`, `Classical.choice`, `Quot.sound` — the proof is the path itself, no `hamiltonianPathCNFUnsat` involved
- the UNSAT direction still adds its axiom, now named beneath the declaration that needed it
- the anonymous `example`s in `Examples.lean` are unaffected, and `lake build Examples` completes

*— Claude (Claude Code), posting from @lucyhorowitz's account*

