### PR TITLE
Fix the widget commands outside the LeanHoG namespace, and make #show_hamiltonian_path show the path

### DIFF
--- a/LeanHoG/Tactic/Basic.lean
+++ b/LeanHoG/Tactic/Basic.lean
@@ -145,7 +145,7 @@ unsafe def findExampleImpl : Tactic.Tactic
               -- Visualize the graph we used to close the goal
               -- TODO: Make this an option
               let vizf ← ``((Graph.toVisualizationFormat $graphIdent))
-              let wis ← `(Widget.widgetInstanceSpec| $(mkIdent `visualize) with $vizf)
+              let wis ← `(Widget.widgetInstanceSpec| $(mkIdent ``visualize) with $vizf)
               let wi : Expr ← Widget.elabWidgetInstanceSpec wis
               let wi ← Widget.evalWidgetInstance wi
               Widget.savePanelWidgetInfo wi.javascriptHash wi.props stx

--- a/LeanHoG/Widgets.lean
+++ b/LeanHoG/Widgets.lean
@@ -51,7 +51,7 @@ This is done using the `https://js.cytoscape.org/` javascript library. -/
 def elabVisualizeGraphCmd : CommandElab
   | stx@`(#show $g) => liftTermElabM do
     let wi : Expr ←
-      elabWidgetInstanceSpec (← `(widgetInstanceSpec| $(mkIdent `visualize) with $(← ``((Graph.toVisualizationFormat $g)))))
+      elabWidgetInstanceSpec (← `(widgetInstanceSpec| $(mkIdent ``visualize) with $(← ``((Graph.toVisualizationFormat $g)))))
     let wi : WidgetInstance ← evalWidgetInstance wi
     savePanelWidgetInfo wi.javascriptHash wi.props stx
   | _ => throwUnsupportedSyntax
@@ -67,7 +67,7 @@ unsafe def elabVisualizeHamiltonianPathCmd : CommandElab
     let hpInst ← mkAppM ``HamiltonianPath #[gg]
     if let .some _ ← synthInstance? hpInst then
       let vizf ← ``((Graph.toVisualizationFormat $G))
-      let wis ← `(Widget.widgetInstanceSpec| $(mkIdent `visualize) with $vizf)
+      let wis ← `(Widget.widgetInstanceSpec| $(mkIdent ``visualize) with $vizf)
       let wi : Expr ← Widget.elabWidgetInstanceSpec wis
       let wi ← Widget.evalWidgetInstance wi
       savePanelWidgetInfo wi.javascriptHash wi.props stx

--- a/LeanHoG/Widgets.lean
+++ b/LeanHoG/Widgets.lean
@@ -66,7 +66,12 @@ unsafe def elabVisualizeHamiltonianPathCmd : CommandElab
     let gg : Expr ← elabTerm G none
     let hpInst ← mkAppM ``HamiltonianPath #[gg]
     if let .some _ ← synthInstance? hpInst then
-      let vizf ← ``((Graph.toVisualizationFormat $G))
+      -- `buildVisualizationInstance`, not `Graph.toVisualizationFormat`: the latter
+      -- emits only `vertexSize` and `edgeList`, so the path the command exists to
+      -- display was never in the payload and `#show_hamiltonian_path G` drew the
+      -- same picture as `#show G`. The instance is known to exist here, having just
+      -- been synthesized.
+      let vizf ← ``((buildVisualizationInstance $G))
       let wis ← `(Widget.widgetInstanceSpec| $(mkIdent ``visualize) with $vizf)
       let wi : Expr ← Widget.elabWidgetInstanceSpec wis
       let wi ← Widget.evalWidgetInstance wi


### PR DESCRIPTION
Two bugs in the visualization commands, one commit each. Based on `main` and independent of #61, #62 and #67 — nothing here touches the tactics.

**The widget name was resolved at the use site.** Closes #65. All three call sites built their identifier with `mkIdent `visualize``, which bypasses hygiene, so `visualize` was looked up where the command is *used* rather than where the widget is defined. From outside `namespace LeanHoG`, on `main`:

```lean
import LeanHoG
open LeanHoG in load_graph W "build/graphs/204.json"
#show W                     -- error: Unknown identifier `visualize`
#check_traceable W
#show_hamiltonian_path W    -- error: Unknown identifier `visualize`
example : ∃ (G : LeanHoG.Graph), G.traceable ∧ … := by find_example  -- fails, goal left
```

`open LeanHoG` worked around it, and `Examples.lean` sits inside the namespace, which is why nothing in the repo saw it. Now that `import LeanHoG` pulls in every module, an importer who never opens the namespace is a realistic case: the graph, the tactics and the other commands all work unqualified, and only the visualization failed.

The fix is `` ``visualize ``, which resolves to `LeanHoG.visualize` where it is written and is checked to exist at that point. Worth noting that the other names in the same quotations — `Graph.toVisualizationFormat` among them — were never affected: a quotation resolves what it contains, and only `mkIdent` opted out of that. That is exactly why the error named `visualize` alone.

**`#show_hamiltonian_path` never sent the path.** Separate bug, found while fixing the first. The command synthesized the `HamiltonianPath G` instance, confirmed it, and then handed the widget `Graph.toVisualizationFormat G`, which emits only `vertexSize` and `edgeList`. So the path was not in the payload and the command drew the same picture as plain `#show`:

```lean
#eval Graph.toVisualizationFormat W
-- {"vertexSize": 6, "edgeList": [[0, 1], [0, 2], …]}
#eval buildVisualizationInstance W
-- {"vertexSize": 6, "hamiltonianPath": [0, 1, 5, 2, 4, 3], "edgeList": …}
```

`buildVisualizationInstance` already existed for precisely this, unused, directly above the command, and the javascript already reads the key it produces (`props.hamiltonianPath`, `widget/src/graphVisualization.jsx:12`). One line. Filed separately as #70 for the record, which this PR closes.

Testing:

- the repro above fails on `main` at all three sites — two `Unknown identifier` errors and a `find_example` that leaves the goal — and all four commands succeed on this branch
- `#show_hamiltonian_path` twice on the same graph still works, both when the instance was just registered and when it already existed
- the payloads compared with `#eval`, as above
- `lake build LeanHoG` completes; `Examples.lean` is unchanged and unaffected, all of its uses being inside the namespace

The rendering itself I could not check from the terminal, only the payload crossing into the widget, so worth an eyeball in the editor before merging.

Closes #65 and #70.

*— Claude (Claude Code), posting from @lucyhorowitz's account*

