### PR TITLE
Check the solver's assignment before building a certificate from it

### DIFF
--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -74,6 +74,32 @@ unsafe def searchForHamiltonianPathAux (graphName : Name) (graph : Q(Graph))
         | none => throwError "invalid index ({i},{j})"
         | some (_, true) => path := path.set! j i
         | some (_, false) => continue
+    -- The assignment is the solver's word for it, so check that it really describes
+    -- a Hamiltonian path before building a certificate out of it.
+    --
+    -- Soundness does not rest on this check. `hamiltonianPathOfData` proves every
+    -- step by `Eq.refl` at `decide` — one adjacency, then `Walk.isPath`, then
+    -- `Path.isHamiltonian` — so a bogus path cannot be accepted. But it is the
+    -- *kernel* that rejects it, as an `of_decide_eq_true` type mismatch that says
+    -- nothing about a solver, and the kernel check is deferred, so the command gets
+    -- as far as reporting that it registered a certificate first. Checking here
+    -- reports what actually went wrong, and stops before anything claims success.
+    let vs := path.toList
+    let solverBlame := m!"The solver named by `leanHoG.solverCmd` ({cadicalExe}) is \
+      not answering correctly."
+    if vs.mergeSort (· ≤ ·) ≠ List.range G.vertexSize then
+      throwError "the SAT solver returned an assignment that does not describe a \
+        Hamiltonian path in {graphName}: {toString vs} is not a permutation of the \
+        {G.vertexSize} vertices. {solverBlame}"
+    for uv in vs.zip vs.tail do
+      let (u, v) := uv
+      if hu : u < G.vertexSize then
+        if hv : v < G.vertexSize then
+          unless G.badjacent ⟨u, hu⟩ ⟨v, hv⟩ do
+            throwError "the SAT solver returned an assignment that does not describe \
+              a Hamiltonian path in {graphName}: {u} and {v} are consecutive on the \
+              returned path {toString vs}, but are not adjacent in the graph. \
+              {solverBlame}"
     let hpQ := hamiltonianPathOfData graph ⟨path.toList⟩
     -- The certificate to hand to `path_of_cert`. `hamiltonianPathOfData` returns a
     -- self-contained term, so a declaration is a convenience and never a necessity:


### PR DESCRIPTION
Closes #63. Stacked on #62, which rewrote the SAT branch this touches — base is `fix/duplicate-certificate-decl`, so the diff here is one hunk in `searchForHamiltonianPathAux`. GitHub will retarget to `main` when #62 merges.

**Soundness was never the problem and is unchanged.** `hamiltonianPathOfData` proves every step by `Eq.refl` at `decide` — one adjacency per step, then `Walk.isPath`, then `Path.isHamiltonian` — so a bogus path cannot be accepted. The kernel remains the thing that guarantees that.

What was wrong is everything around it. The rejection arrived as

```
error: (kernel) application type mismatch
  of_decide_eq_true (Eq.refl true)
argument has type
  true = true
but function has type
  decide (LeanHoG.Graph.adjacent ⟨0, ⋯⟩ ⟨0, ⋯⟩) = true → LeanHoG.Graph.adjacent ⟨0, ⋯⟩ ⟨0, ⋯⟩
```

which names neither the graph nor the solver, and — the kernel check being deferred — arrived *after* the command had logged `found Hamiltonian path, registered as W.HamiltonianPathI`. So the command simultaneously claimed to have registered a certificate and failed to.

The path data is in hand before the certificate is built and `G` is a real value at that point, so the two properties the certificate asserts are now checked directly: that the path lists every vertex exactly once, and that consecutive vertices are adjacent. The permutation half is one comparison against `List.range`, which covers length, bounds and distinctness together. Both failures name the graph, the offending data and the solver being blamed, and neither can be preceded by a success message, since the check runs before anything is built or registered.

Tested with two stub solvers, each exiting 10 with `s SATISFIABLE` and an assignment sized to the CNF:

**A non-permutation** — all-false, so every position keeps its initial vertex:

```
error: the SAT solver returned an assignment that does not describe a Hamiltonian
path in P: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] is not a permutation of the 10 vertices.
The solver named by `leanHoG.solverCmd` (…/lying-solver.sh) is not answering correctly.
```

**A permutation that is not a path** — the identity on the Petersen graph, where `1–2` is not an edge:

```
error: the SAT solver returned an assignment that does not describe a Hamiltonian
path in P: 1 and 2 are consecutive on the returned path [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
but are not adjacent in the graph. The solver named by `leanHoG.solverCmd`
(…/lying-solver-perm.sh) is not answering correctly.
```

Both reproduce through the command and through the tactic. Alongside that: an honest cadical is unaffected in both directions, a named theorem on the SAT side still lists only `propext`, `Classical.choice`, `Quot.sound`, `#show_hamiltonian_path` reports nothing registered for a graph whose runs all failed, and `Examples.lean` builds unchanged.

Two things noticed while writing the stubs, neither addressed here:

- the solver is invoked as `--no-binary --lrat=true -t 300 - <lrat-path>`, so the CNF goes in on **stdin** and the file argument is where the LRAT proof is expected. Worth knowing for anyone else writing a stub; my first attempt parsed the LRAT path as the CNF and got nowhere.
- an assignment that is short, or that omits a variable the encoding asks about, still fails with `invalid index (0,0)` from the loop above this check. That is a separate unhelpful message on a different input, and I have left it alone rather than widen this PR.

*— Claude (Claude Code), posting from @lucyhorowitz's account*
