### PR TITLE
Read graphs from graph6

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -89,16 +89,27 @@ load_graph hog_904 "build/graphs/904.json"
 -- The strings printed by `Petersen.g6` and `Wheel.g6` above are graph6, nauty's
 -- encoding of a graph as printable ASCII and the format `geng`, `networkx`,
 -- SageMath and HoG all speak. `load_graph_from_g6` reads one back in, needing
--- neither HoG nor the network.
-load_graph_from_g6 PetersenFromG6 "IsP@OkWHG"
+-- neither HoG nor the network. The string below is the Petersen graph in its
+-- textbook labelling: the outer 5-cycle on 0-4, the inner pentagram 5-7-9-6-8,
+-- and a spoke from `i` to `i + 5`.
+load_graph_from_g6 PetersenFromG6 "IheA@GUAo"
 #show PetersenFromG6
-#eval PetersenFromG6.numberOfConnectedComponents
+
+-- A graph6 string carries the edge set and nothing else, so the invariants
+-- available on `PetersenFromG6` are the ones computed from the edge set.
+-- Invariants that Lean-HoG reads off a certificate — the number of connected
+-- components, a two-colouring, a Hamiltonian path — have no instance here; a
+-- HoG JSON file supplies those, and the tactics compute them on demand.
 #eval PetersenFromG6.degreeSequence
 
--- `Graph.toGraph6` encodes a graph under its own vertex labelling. For the
--- Petersen graph HoG's labelling is the canonical one, so this returns the
--- string it was read from.
+-- TODO: Prove that it is isomorphic to Petersen once we have a way to express isomorphism.
+
+-- `Graph.toGraph6` encodes a graph under its own vertex labelling, so it returns
+-- the string the graph was read from rather than a canonical form. HoG states
+-- `Petersen` in nauty's canonical labelling, so the two encodings differ even
+-- though the graphs are isomorphic.
 #eval PetersenFromG6.toGraph6
+#eval PetersenFromG6.toGraph6 == Petersen.g6
 
 -- A graph6 file holds one graph per line, which is how `geng` writes a whole
 -- family at once. Each line becomes its own declaration, numbered from zero.

--- a/Examples.lean
+++ b/Examples.lean
@@ -83,6 +83,31 @@ load_graph hog_904 "build/graphs/904.json"
 -- #search_hog hog{ traceable = true ∧ numberOfVertices > 3 ∧ minimumDegree < numberOfVertices / 2}
 
 -----------------------------------------
+-- Reading graphs from graph6
+-----------------------------------------
+
+-- The strings printed by `Petersen.g6` and `Wheel.g6` above are graph6, nauty's
+-- encoding of a graph as printable ASCII and the format `geng`, `networkx`,
+-- SageMath and HoG all speak. `load_graph_from_g6` reads one back in, needing
+-- neither HoG nor the network.
+load_graph_from_g6 PetersenFromG6 "IsP@OkWHG"
+#show PetersenFromG6
+#eval PetersenFromG6.numberOfConnectedComponents
+#eval PetersenFromG6.degreeSequence
+
+-- `Graph.toGraph6` encodes a graph under its own vertex labelling. For the
+-- Petersen graph HoG's labelling is the canonical one, so this returns the
+-- string it was read from.
+#eval PetersenFromG6.toGraph6
+
+-- A graph6 file holds one graph per line, which is how `geng` writes a whole
+-- family at once. Each line becomes its own declaration, numbered from zero.
+load_graphs_from_g6_file Sample "examples/hog-sample.g6"
+#show Sample_1
+#eval Sample_1.degreeSequence
+#eval [Sample_0.vertexSize, Sample_1.vertexSize, Sample_2.vertexSize, Sample_3.vertexSize]
+
+-----------------------------------------
 -- Hamiltonian paths
 -----------------------------------------
 

--- a/Graph6Tests.lean
+++ b/Graph6Tests.lean
@@ -1,0 +1,144 @@
+import LeanHoG.LoadGraph
+
+/-!
+# Tests for the graph6 codec
+
+`#guard` fails elaboration when its argument evaluates to `false`, so
+`lake build Graph6Tests` is the whole test run.
+
+The strings in `hogCanonicalForms` are the `canonicalForm` fields of the graphs
+in `graphs/`, which HoG states in the same vertex labelling as the `edges` field
+of the same file. They serve both as round-trip inputs and, against the loaded
+JSON, as a check on the decoded edge set.
+-/
+
+namespace LeanHoG
+
+/-- Whether `decode` accepts `s` and `encodeData` returns it unchanged. -/
+def roundTrips (s : String) : Bool :=
+  match Graph6.decode s with
+  | .ok data => Graph6.encodeData data == s
+  | .error _ => false
+
+/-- Whether `decode` rejects `s`. -/
+def rejects (s : String) : Bool :=
+  match Graph6.decode s with
+  | .ok _ => false
+  | .error _ => true
+
+/-- The vertex count and edge list `decode` produces, or `none` on failure. -/
+def decoded (s : String) : Option (Nat × List (Nat × Nat)) :=
+  match Graph6.decode s with
+  | .ok data => some (data.vertexSize, data.edges.toList)
+  | .error _ => none
+
+/-- The edges of `G` as pairs of vertex numbers, in the order `edgeSet` holds them. -/
+def edgePairs (G : Graph) : List (Nat × Nat) :=
+  G.edgeSet.foldr (fun e acc => (e.fst.val, e.snd.val) :: acc) []
+
+/-- Whether the pairs strictly increase lexicographically. -/
+def lexIncreasing : List (Nat × Nat) → Bool
+  | [] | [_] => true
+  | a :: b :: rest =>
+    (a.1 < b.1 || (a.1 == b.1 && a.2 < b.2)) && lexIncreasing (b :: rest)
+
+def hogCanonicalForms : List String :=
+  [ "Ms??OHGP?ccKEOH_?"
+  , "}???????????????????????????????B???CO?@C??A_??I???K???@C???C_???S???C_???@?_???`???GG????`????AA????_O?????o????B??????B?????@G?????C_?????`?????OO?????AA?????AA?????@@????A??C????G??G????_?A?????_?@????????C??A_g??@??@OS???A_KO?????S?M??????NG???????qo????????a_a??????CSCC??????KGP??????@H?g????????Oco???????_Z???"
+  , "Z~~vnZjvUtw~nSmis{{k~a^||QBtQJNHLU[VQ^BxkFnDK\\zEEvn@Tn^_Tn^w"
+  , "L@GOOGA?GAG@_C"
+  , "E}lw"
+  , "F???G"
+  , "UKb?GGGA@fi]Uog?S??G^@KwBp_Fb?Fb?w?^U?Fo"
+  , "XcG_COOK_G?DAA@G_oOCQQ@@@o??i@?K?@?x?oAO_@kgD?UF_@o"
+  , "D^{"
+  , "X`Ic?dA??O???POO@A__PACc?Z@CA_HGGCa_@N??cIPGJ?We??{"
+  , "IsP@OkWHG"
+  , "\\_?O__AGP?@GACHG?qaCAaAP?_C?K?AT?G?E?@`?Ho_GC??CA?L??F`?w?EdO?AEK??^?" ]
+
+/-! ## Round trips over the twelve HoG canonical forms -/
+
+#guard hogCanonicalForms.length == 12
+#guard hogCanonicalForms.all roundTrips
+
+/-! ## The decoded graph agrees with the JSON of the same graph -/
+
+load_graph hog_660 "graphs/660.json"
+load_graph_from_g6 g6_660 "IsP@OkWHG"
+
+#guard hog_660.vertexSize == g6_660.vertexSize
+#guard edgePairs hog_660 == edgePairs g6_660
+#guard hog_660.toGraph6 == "IsP@OkWHG"
+
+load_graph hog_1030 "graphs/1030.json"
+load_graph_from_g6 g6_1030 "}???????????????????????????????B???CO?@C??A_??I???K???@C???C_???S???C_???@?_???`???GG????`????AA????_O?????o????B??????B?????@G?????C_?????`?????OO?????AA?????AA?????@@????A??C????G??G????_?A?????_?@????????C??A_g??@??@OS???A_KO?????S?M??????NG???????qo????????a_a??????CSCC??????KGP??????@H?g????????Oco???????_Z???"
+
+#guard hog_1030.vertexSize == 62
+#guard edgePairs hog_1030 == edgePairs g6_1030
+
+/-! ## Decoded edges are lexicographically ordered, as `graphOfData` requires -/
+
+#guard lexIncreasing (edgePairs g6_660)
+#guard lexIncreasing (edgePairs g6_1030)
+
+/-! ## Small graphs, by hand -/
+
+#guard decoded "?" == some (0, [])
+#guard decoded "@" == some (1, [])
+#guard decoded "A?" == some (2, [])
+#guard decoded "A_" == some (2, [(0, 1)])
+#guard decoded "D^{" == some (5, [(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)])
+#guard decoded "F???G" == some (7, [(5, 6)])
+
+/-! ## The optional header and surrounding whitespace -/
+
+#guard decoded ">>graph6<<D^{" == decoded "D^{"
+#guard decoded " \tD^{\n" == decoded "D^{"
+#guard decoded ">>graph6<< D^{ " == decoded "D^{"
+
+/-! ## Vertex counts needing the wide `N(n)` forms
+
+No HoG example exceeds 62 vertices, so the `~` and `~~` branches are exercised
+by encoding paths of the relevant sizes.
+-/
+
+/-- The path on `n` vertices. -/
+def pathData (n : Nat) : GraphData :=
+  { vertexSize := n, edges := ((List.range (n - 1)).map (fun i => (i, i + 1))).toArray }
+
+#guard Graph6.encodeVertexCount 62 == "}"
+#guard Graph6.encodeVertexCount 63 == "~??~"
+#guard Graph6.encodeVertexCount 258047 == "~}~~"
+#guard Graph6.encodeVertexCount 258048 == "~~???~??"
+
+#guard roundTrips (Graph6.encodeData (pathData 62))
+#guard roundTrips (Graph6.encodeData (pathData 63))
+#guard roundTrips (Graph6.encodeData (pathData 70))
+#guard decoded (Graph6.encodeData (pathData 70)) == some (70, (pathData 70).edges.toList)
+
+/-! ## Rejected input -/
+
+#guard rejects ""
+#guard rejects "D^"      -- one byte of adjacency data short
+#guard rejects "D^{{"    -- one byte too many
+#guard rejects "D^,"     -- ',' is below '?'
+#guard rejects "Dé{"     -- not ASCII
+#guard rejects "~"       -- truncated wide vertex count
+#guard rejects "~??"     -- truncated 18-bit vertex count
+#guard rejects "~~?????" -- truncated 36-bit vertex count
+
+/-! ## Loading a whole graph6 file -/
+
+load_graphs_from_g6_file Sample "examples/hog-sample.g6"
+
+#guard Sample_0.vertexSize == 10
+#guard Sample_1.vertexSize == 6
+#guard Sample_2.vertexSize == 5
+#guard Sample_3.vertexSize == 7
+#guard edgePairs Sample_0 == edgePairs hog_660
+#guard Sample_0.toGraph6 == "IsP@OkWHG"
+#guard Sample_1.toGraph6 == "E}lw"
+#guard Sample_2.toGraph6 == "D^{"
+#guard Sample_3.toGraph6 == "F???G"
+
+end LeanHoG

--- a/LeanHoG.lean
+++ b/LeanHoG.lean
@@ -1,6 +1,7 @@
 import LeanHoG.Certificate
 import LeanHoG.Edge
 import LeanHoG.Graph
+import LeanHoG.Graph6
 import LeanHoG.Invariant
 import LeanHoG.JsonData
 import LeanHoG.LoadGraph

--- a/LeanHoG/Graph6.lean
+++ b/LeanHoG/Graph6.lean
@@ -1,0 +1,145 @@
+import LeanHoG.Graph
+import LeanHoG.JsonData
+
+/-!
+# The graph6 encoding
+
+graph6, from nauty, encodes an undirected simple graph as a string of printable
+ASCII:
+
+```
+[>>graph6<<] N(n) R(x)
+```
+
+Every byte lies in `'?' .. '~'` (63 .. 126) and carries the six-bit value
+`byte - 63`.
+
+`N(n)` is the vertex count: one byte `n + 63` when `n ≤ 62`; `'~'` followed by
+`n` as 18 bits in three bytes when `63 ≤ n ≤ 258047`; `'~~'` followed by `n` as
+36 bits in six bytes above that.
+
+`R(x)` is the upper triangle of the adjacency matrix as a bit vector in
+column-major order,
+
+```
+a(0,1), a(0,2), a(1,2), a(0,3), a(1,3), a(2,3), a(0,4), …
+```
+
+right-padded with zeros to a multiple of six, each six-bit group emitted as its
+value plus 63. The bit for the edge `i < j` therefore sits at index
+`j*(j-1)/2 + i`, and reading those bits with `i` in the outer loop visits the
+edges in lexicographic order.
+
+This module handles graph6. sparse6, the `:`-prefixed format, is a separate
+encoding.
+-/
+
+namespace LeanHoG
+
+namespace Graph6
+
+/-- The header nauty optionally writes ahead of a graph6 string. -/
+def header : String := ">>graph6<<"
+
+/-- Turn a graph6 string into its six-bit values, rejecting bytes outside the
+    printable range. -/
+def toBytes (s : String) : Except String (Array Nat) := do
+  let mut bytes : Array Nat := #[]
+  for c in s.toList do
+    let n := c.toNat
+    if 63 ≤ n && n ≤ 126 then
+      bytes := bytes.push (n - 63)
+    else
+      throw s!"graph6: character {repr c} at position {bytes.size} is outside the printable range '?'..'~'"
+  return bytes
+
+/-- Read `k` consecutive six-bit groups starting at `start` as one big-endian number. -/
+def readBase64 (bytes : Array Nat) (start k : Nat) : Except String Nat :=
+  if start + k ≤ bytes.size then
+    .ok <| (List.range k).foldl (fun acc i => (acc <<< 6) ||| bytes.getD (start + i) 0) 0
+  else
+    throw s!"graph6: the vertex count needs {k} bytes from position {start}, but the string has only {bytes.size}"
+
+/-- Emit `v` as `k` six-bit groups, most significant first. -/
+def writeBase64 (k v : Nat) : String :=
+  String.ofList <| (List.range k).map fun i =>
+    Char.ofNat (((v >>> (6 * (k - 1 - i))) % 64) + 63)
+
+/-- Read `N(n)`: the vertex count, and how many bytes it occupied. -/
+def decodeVertexCount (bytes : Array Nat) : Except String (Nat × Nat) := do
+  match bytes[0]? with
+  | none => throw "graph6: the string is empty"
+  | some b0 =>
+    if b0 ≤ 62 then
+      return (b0, 1)
+    -- `b0 = 63`, the byte '~': a wide vertex count follows
+    else if bytes.getD 1 0 ≤ 62 then
+      return (← readBase64 bytes 1 3, 4)
+    else
+      return (← readBase64 bytes 2 6, 8)
+
+/-- Write `N(n)`. -/
+def encodeVertexCount (n : Nat) : String :=
+  if n ≤ 62 then
+    String.singleton (Char.ofNat (n + 63))
+  else if n ≤ 258047 then
+    "~" ++ writeBase64 3 n
+  else
+    "~~" ++ writeBase64 6 n
+
+/-- The number of bytes `R(x)` occupies for a graph on `n` vertices: one per
+    six bits of the upper triangle, rounded up. -/
+def payloadSize (n : Nat) : Nat := (n * (n - 1) / 2 + 5) / 6
+
+/-- The bit for the edge `i < j` within `R(x)`. -/
+def bitIndex (i j : Nat) : Nat := j * (j - 1) / 2 + i
+
+/-- Bit `k` of `R(x)`, counting from the most significant bit of the first byte. -/
+def bit (payload : Array Nat) (k : Nat) : Bool :=
+  ((payload.getD (k / 6) 0 >>> (5 - k % 6)) &&& 1) == 1
+
+/-- Decode a graph6 string. The header is optional and surrounding whitespace
+    is ignored. -/
+def decode (s : String) : Except String GraphData := do
+  let s := s.trimAscii.toString
+  let s := if s.startsWith header then
+      String.ofList (s.toList.drop header.length) |>.trimAscii.toString
+    else s
+  let bytes ← toBytes s
+  let (n, used) ← decodeVertexCount bytes
+  let payload := bytes.extract used bytes.size
+  let expected := payloadSize n
+  if payload.size ≠ expected then
+    throw s!"graph6: a graph on {n} vertices needs {expected} bytes of adjacency data, but {payload.size} follow the vertex count"
+  let mut edges : Array (Nat × Nat) := #[]
+  for i in [0:n] do
+    for j in [i+1:n] do
+      if bit payload (bitIndex i j) then
+        edges := edges.push (i, j)
+  return { vertexSize := n, edges := edges }
+
+/-- Encode a graph given as `GraphData`. Inverse of `decode`. -/
+def encodeData (D : GraphData) : String :=
+  let n := D.vertexSize
+  let bits : Array Bool := Id.run do
+    let mut bits := Array.replicate (n * (n - 1) / 2) false
+    for (a, b) in D.edges do
+      let i := min a b
+      let j := max a b
+      if i < j && j < n then
+        bits := bits.set! (bitIndex i j) true
+    return bits
+  let payload := String.ofList <| (List.range (payloadSize n)).map fun b =>
+    Char.ofNat <| 63 + (List.range 6).foldl
+      (fun acc k => acc * 2 + (if bits.getD (6 * b + k) false then 1 else 0)) 0
+  encodeVertexCount n ++ payload
+
+end Graph6
+
+/-- The graph6 encoding of `G` under its own vertex labelling. -/
+def Graph.toGraph6 (G : Graph) : String :=
+  Graph6.encodeData
+    { vertexSize := G.vertexSize
+      edges := G.edgeSet.foldl (fun acc e => acc.push (e.fst.val, e.snd.val)) #[] }
+
+end LeanHoG

--- a/LeanHoG/LoadGraph.lean
+++ b/LeanHoG/LoadGraph.lean
@@ -2,6 +2,7 @@ import Lean
 import Qq
 
 import LeanHoG.Graph
+import LeanHoG.Graph6
 import LeanHoG.Invariant.G6
 import LeanHoG.Invariant.Bipartite.Certificate
 import LeanHoG.Invariant.ConnectedComponents.Certificate
@@ -129,6 +130,57 @@ unsafe def loadGraphImpl : Elab.Command.CommandElab
     let graphName := graphName.getId
     let jsonData ← loadJSONData JSONData fileName.getString
     loadGraphAux graphName jsonData
+
+  | _ => Elab.throwUnsupportedSyntax
+
+syntax (name := loadGraphFromG6) "load_graph_from_g6" ident str : command
+syntax (name := loadGraphsFromG6File) "load_graphs_from_g6_file" ident str : command
+
+/-- Present bare graph data as a `JSONData` carrying no invariant certificates. -/
+def jsonDataOfGraphData (data : GraphData) : JSONData where
+  hogId := none
+  graph := data
+  canonicalForm? := none
+  connectedComponents? := none
+  hamiltonianPath? := none
+  twoColoring? := none
+  oddClosedWalk? := none
+  neighborhoodMap? := none
+
+/-- `load_graph_from_g6 <ID> <g6>` loads the graph encoded by the graph6 string
+    `<g6>` into the Lean identifier `ID`. -/
+@[command_elab loadGraphFromG6]
+unsafe def loadGraphFromG6Impl : Elab.Command.CommandElab
+  | `(load_graph_from_g6 $graphName $g6) => do
+    let data ← liftExcept <| Graph6.decode g6.getString
+    loadGraphAux graphName.getId (jsonDataOfGraphData data)
+
+  | _ => Elab.throwUnsupportedSyntax
+
+/-- `load_graphs_from_g6_file <ID> <file>` loads every graph in a graph6 file,
+    one per line, into `ID_0`, `ID_1`, … in the order the lines appear. Blank
+    lines and a lone `>>graph6<<` header line are skipped. -/
+@[command_elab loadGraphsFromG6File]
+unsafe def loadGraphsFromG6FileImpl : Elab.Command.CommandElab
+  | `(load_graphs_from_g6_file $graphName $fileName) => do
+    let path := fileName.getString
+    let contents ← IO.FS.readFile path
+    let mut lineNo : Nat := 0
+    let mut count : Nat := 0
+    for raw in contents.splitOn "\n" do
+      lineNo := lineNo + 1
+      let line := raw.trimAscii.toString
+      unless line.isEmpty || line == Graph6.header do
+        match Graph6.decode line with
+        | .error msg => throwError "{path}:{lineNo}: {msg}"
+        | .ok data =>
+          loadGraphAux (graphName.getId.appendAfter s!"_{count}") (jsonDataOfGraphData data)
+          count := count + 1
+    if count = 0 then
+      logWarning m!"{path} contains no graph6 lines"
+    else
+      logInfo m!"loaded {count} graphs from {path} as \
+                 {graphName.getId.appendAfter "_0"} … {graphName.getId.appendAfter s!"_{count - 1}"}"
 
   | _ => Elab.throwUnsupportedSyntax
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,38 @@ You can check that it loaded it with `#check <graphName>`.
 ```
 
 
+### Reading graphs from graph6
+
+[graph6](https://users.cecs.anu.edu.au/~bdm/data/formats.txt) is nauty's encoding of an undirected simple graph as a short string of printable ASCII, and is what `geng`, `nauty`, `networkx`, SageMath and the House of Graphs hand out. HoG's `canonicalForm` field is a graph6 string.
+
+`load_graph_from_g6 <graphName> <g6>` loads the graph encoded by a graph6 string:
+
+```lean
+load_graph_from_g6 Petersen "IsP@OkWHG"
+#show Petersen
+#eval Petersen.numberOfConnectedComponents
+```
+
+`load_graphs_from_g6_file <graphName> <file>` loads every graph in a graph6 file, one per line as `geng` writes them, into `graphName_0`, `graphName_1`, … in the order the lines appear. Blank lines and a lone `>>graph6<<` header line are skipped.
+
+```lean
+load_graphs_from_g6_file Sample "examples/hog-sample.g6"
+#show Sample_0
+```
+
+Each graph in the file becomes a separate compiled declaration, so a file with thousands of lines takes a correspondingly long time to elaborate.
+
+Neither command attaches any invariant certificate, so invariants of a graph read from graph6 are decided by search rather than read off a certificate.
+
+`Graph.toGraph6` goes the other way, encoding a graph under its own vertex labelling:
+
+```lean
+#eval Petersen.toGraph6
+```
+
+Only graph6 is supported; sparse6, the `:`-prefixed format, is not.
+
+
 ### Visualization widget
 
 Lean-HoG can visualize the imported graphs in the Lean infoview using 

--- a/examples/hog-sample.g6
+++ b/examples/hog-sample.g6
@@ -1,0 +1,4 @@
+IsP@OkWHG
+E}lw
+D^{
+F???G

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -64,8 +64,7 @@ target buildWidget pkg : Unit := do
 lean_lib LeanHoG where
   needs := #[buildWidget]
 
-lean_lib Examples where
-  needs := #[LeanHoG]
+lean_lib Graph6Tests
 
-lean_lib Graph6Tests where
-  needs := #[LeanHoG]
+lean_lib Examples where
+  needs := #[LeanHoG, Graph6Tests]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -66,3 +66,6 @@ lean_lib LeanHoG where
 
 lean_lib Examples where
   needs := #[LeanHoG]
+
+lean_lib Graph6Tests where
+  needs := #[LeanHoG]


### PR DESCRIPTION
graph6 is nauty's encoding and what HoG, geng, networkx and SageMath all hand out, so it is the format to read if a graph is to come from anywhere but this library's JSON. HoG's `canonicalForm` field was already a graph6 string, attached to a graph as its `G6` instance, but nothing could read one.

`LeanHoG/Graph6.lean` is the codec, pure Lean with no dependency outside the repo: decode to `GraphData`, `encodeData` back, and `Graph.toGraph6`. Two commands in `LoadGraph.lean`, `load_graph_from_g6` for a literal and `load_graphs_from_g6_file` for a one-graph-per-line file, hand the result to the existing `loadGraphAux`.

Neither command sets `canonicalForm?`, so no `G6` instance is added: an arbitrary graph6 string encodes the labelling it was given and need not be canonical, which is what `G6` and `Graph.g6` currently mean.

`Graph6Tests.lean` is a lake target of `#guard`s. It round-trips all twelve canonical forms in `graphs/`, checks the decoded edge set against the JSON of the same graph, covers the wide `N(n)` forms that no HoG example reaches, and pins the rejection of malformed input. `lake build Graph6Tests` passes.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)