### PR TITLE
compute bipartiteness certificates with a check_bipartite command

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -4,6 +4,7 @@ import LeanHoG.Widgets
 import LeanHoG.Tactic.SearchDSL
 import LeanHoG.Tactic.Basic
 import LeanHoG.Invariant.HamiltonianPath.Tactic
+import LeanHoG.Invariant.Bipartite.Tactic
 
 namespace LeanHoG
 
@@ -124,6 +125,44 @@ load_graphs_from_g6_file Sample "examples/hog-sample.g6"
 #eval [Sample_0.vertexSize, Sample_1.vertexSize, Sample_2.vertexSize, Sample_3.vertexSize]
 
 -----------------------------------------
+-- Bipartiteness
+-----------------------------------------
+
+-- A graph that arrives without a two-colouring — from graph6, from a JSON file that
+-- omits the field, or from `#download` when HoG records none — leaves `Graph.bipartite`
+-- to the generic `Decidable` instance, which enumerates all `2^n` maps
+-- `G.vertex → Fin 2`. That is why `#eval Cube5.bipartite` is commented out above:
+-- `Cube5` has 32 vertices.
+--
+-- `#check_bipartite` computes a certificate by breadth-first search and registers it as
+-- an instance, and the `#eval` then reads the answer off that certificate.
+#check_bipartite Cube5
+#eval Cube5.bipartite
+
+-- The search roots a tree in each connected component and colours every vertex by the
+-- parity of its distance from that root. Either no edge joins two vertices of the same
+-- colour, and the colouring is a `TwoColoring`, or some edge does, and that edge
+-- together with the two tree paths back to the common ancestor of its endpoints closes
+-- a walk of odd length — an `OddClosedWalk`, which refutes bipartiteness.
+#check_bipartite PetersenFromG6
+#eval PetersenFromG6.bipartite
+
+-- As with Hamiltonian paths, the command only reports what it found, and the tactic of
+-- the same name without the leading `#` puts the fact into a proof. It decides both
+-- directions, and neither direction rests on an axiom or on an external solver.
+example : Cube5.bipartite := by
+  check_bipartitea Cube5
+
+example : ¬PetersenFromG6.bipartite := by
+  check_bipartitea PetersenFromG6
+
+-- `check_bipartite` leaves the fact in the context instead of closing the goal, and
+-- `with h` gives it a name.
+example : ¬PetersenFromG6.bipartite := by
+  check_bipartite PetersenFromG6 with h
+  exact h
+
+-----------------------------------------
 -- Hamiltonian paths
 -----------------------------------------
 
@@ -227,10 +266,6 @@ example : ∃ (G : Graph), G.traceable ∧ G.vertexSize > 3 ∧ (G.minimumDegree
 
 section Capstone
 
--- Deciding `¬ G.bipartite` with no certificate to hand searches for a
--- two-colouring, which overruns the default recursion budget.
-set_option maxRecDepth 10000
-
 /-- Traceability is not a function of the degree sequence: there are two
     connected, non-bipartite graphs with the same degree sequence, one of which
     is traceable and one of which is not. -/
@@ -240,7 +275,9 @@ theorem traceability_not_determined_by_degree_sequence :
       G.connectedGraph ∧ H.connectedGraph ∧
       ¬ G.bipartite ∧ ¬ H.bipartite ∧
       G.traceable ∧ ¬ H.traceable := by
-  refine ⟨Twin1, Twin2, by decide, by decide, by decide, by decide, by decide, ?_, ?_⟩
+  refine ⟨Twin1, Twin2, by decide, by decide, by decide, ?_, ?_, ?_, ?_⟩
+  · check_bipartitea Twin1
+  · check_bipartitea Twin2
   · check_traceablea Twin1
   · check_traceablea Twin2
 

--- a/LeanHoG/Invariant/Bipartite.lean
+++ b/LeanHoG/Invariant/Bipartite.lean
@@ -1,3 +1,5 @@
 import LeanHoG.Invariant.Bipartite.Basic
 import LeanHoG.Invariant.Bipartite.Certificate
 import LeanHoG.Invariant.Bipartite.JsonData
+import LeanHoG.Invariant.Bipartite.Search
+import LeanHoG.Invariant.Bipartite.Tactic

--- a/LeanHoG/Invariant/Bipartite/Basic.lean
+++ b/LeanHoG/Invariant/Bipartite/Basic.lean
@@ -32,6 +32,9 @@ instance (G : Graph) : Decidable G.bipartite :=
 instance Graph.bipartiteFromTwoColoring (G : Graph) [C : TwoColoring G] : Decidable G.bipartite
 := by apply isTrue; exists C
 
+/-- A two-coloring is a certificate for bipartiteness. -/
+theorem TwoColoring.bipartite {G : Graph} (C : TwoColoring G) : Graph.bipartite G := ⟨C, trivial⟩
+
 /-- Having an odd closed walk is an anti-certificate for bipartiteness. -/
 class OddClosedWalk (G : Graph) where
   vertex : G.vertex

--- a/LeanHoG/Invariant/Bipartite/Search.lean
+++ b/LeanHoG/Invariant/Bipartite/Search.lean
@@ -1,0 +1,137 @@
+import LeanHoG.Graph
+import LeanHoG.Invariant.Bipartite.JsonData
+
+namespace LeanHoG
+
+/-- The neighbors of each vertex, indexed by vertex number. -/
+def Graph.adjacencyList (G : Graph) : Array (Array Nat) :=
+  G.edgeSet.foldl
+    (fun adj e => (adj.modify e.fst.val (·.push e.snd.val)).modify e.snd.val (·.push e.fst.val))
+    (Array.replicate G.vertexSize #[])
+
+/-- Adjacency of two vertices given by their numbers, `false` when either is out of
+    range. -/
+def Graph.badjacentNat (G : Graph) (u v : Nat) : Bool :=
+  if hu : u < G.vertexSize then
+    if hv : v < G.vertexSize then G.badjacent ⟨u, hu⟩ ⟨v, hv⟩ else false
+  else false
+
+/-- A breadth-first search forest: one tree per connected component. `color` holds the
+    parity of a vertex's distance from the root of its tree, `parent` its predecessor
+    in that tree, with a root recorded as its own parent. -/
+structure BFSForest where
+  color : Array Nat
+  parent : Array Nat
+  visited : Array Bool
+
+namespace BFSForest
+
+/-- The forest on `n` vertices in which nothing has been visited yet. -/
+def empty (n : Nat) : BFSForest where
+  color := Array.replicate n 0
+  parent := Array.replicate n 0
+  visited := Array.replicate n false
+
+/-- Grow the tree rooted at `root`, visiting every vertex reachable from it that the
+    forest does not already hold, and coloring each by the parity of its distance
+    from `root`. -/
+def exploreFrom (adj : Array (Array Nat)) (root : Nat) (f : BFSForest) : BFSForest := Id.run do
+  let mut f := { f with
+    parent := f.parent.set! root root
+    visited := f.visited.set! root true }
+  let mut queue : Array Nat := #[root]
+  let mut head : Nat := 0
+  while head < queue.size do
+    let u := queue[head]!
+    head := head + 1
+    for v in adj[u]! do
+      unless f.visited[v]! do
+        f := { color := f.color.set! v (1 - f.color[u]!)
+               parent := f.parent.set! v u
+               visited := f.visited.set! v true }
+        queue := queue.push v
+  return f
+
+/-- The vertices from `v` up to the root of its tree, `v` first. -/
+def ancestors (f : BFSForest) (v : Nat) : List Nat :=
+  let rec go : Nat → Nat → List Nat
+    | 0, v => [v]
+    | fuel + 1, v =>
+      let p := f.parent[v]!
+      if p == v then [v] else v :: go fuel p
+  go f.parent.size v
+
+/-- The closed walk through `u`, the tree edges up to the deepest common ancestor of
+    `u` and `v`, the tree edges back down to `v`, and the edge from `v` to `u`. It is
+    listed by its vertices, starting at `u` and not repeating it at the end. `none`
+    when `u` and `v` lie in different trees. -/
+def closedWalkThrough (f : BFSForest) (u v : Nat) : Option (List Nat) :=
+  let up := (f.ancestors u).reverse
+  let vp := (f.ancestors v).reverse
+  let shared := ((up.zip vp).takeWhile (fun p => p.fst == p.snd)).length
+  if shared = 0 then none else some ((up.drop (shared - 1)).reverse ++ vp.drop shared)
+
+end BFSForest
+
+/-- A breadth-first search forest for `G`, rooted once in each connected component. -/
+def Graph.bfsForest (G : Graph) : BFSForest := Id.run do
+  let adj := G.adjacencyList
+  let mut f := BFSForest.empty G.vertexSize
+  for root in List.range G.vertexSize do
+    unless f.visited[root]! do
+      f := f.exploreFrom adj root
+  return f
+
+/-- An edge whose endpoints `color` colors alike, if there is one. -/
+def Graph.monochromaticEdge (G : Graph) (color : Array Nat) : Option (Nat × Nat) :=
+  G.edgeSet.foldl (init := none) fun found e =>
+    match found with
+    | some _ => found
+    | none =>
+      if color[e.fst.val]! == color[e.snd.val]! then some (e.fst.val, e.snd.val) else none
+
+/-- Whether the vertices in `walk` are consecutively adjacent in `G`, the last is
+    adjacent to the first, and there is an odd number of them. -/
+def Graph.isOddClosedWalk (G : Graph) (walk : List Nat) : Bool :=
+  match walk with
+  | [] => false
+  | v :: _ =>
+    walk.length % 2 == 1 &&
+      (walk.zip (walk.tail ++ [v])).all (fun p => G.badjacentNat p.fst p.snd)
+
+/-- What a breadth-first search decides about the bipartiteness of a graph: a coloring
+    of the vertices by the parity of their distance from the root of their component,
+    or a closed walk of odd length. -/
+inductive BipartiteSearchResult where
+  | twoColoring (data : TwoColoringData)
+  | oddClosedWalk (data : OddClosedWalkData)
+
+/-- Decide bipartiteness of `G` by breadth-first search, returning the certificate for
+    whichever answer it reaches.
+
+    A coloring is returned only once `monochromaticEdge` has found no edge to refute
+    it, and the odd closed walk is checked against the graph in the same way before it
+    is returned. Soundness does not rest on either check: `TwoColoringOfData` and
+    `OddClosedWalkOfData` prove every obligation by `Eq.refl` at `decide`, so the
+    kernel rejects data that does not describe what it claims to. But it rejects it as
+    a type mismatch inside a term the user never wrote, and it does so long after the
+    command has reported success, so a search that went wrong is easier to read about
+    here. -/
+def Graph.searchBipartite (G : Graph) : Except String BipartiteSearchResult :=
+  let forest := G.bfsForest
+  match G.monochromaticEdge forest.color with
+  | none =>
+    .ok (.twoColoring ⟨(Array.range G.vertexSize).zip forest.color⟩)
+  | some (u, v) =>
+    match forest.closedWalkThrough u v with
+    | none =>
+      .error s!"the search colored the adjacent vertices {u} and {v} alike, but placed \
+        them in different connected components"
+    | some walk =>
+      if G.isOddClosedWalk walk then
+        .ok (.oddClosedWalk ⟨walk⟩)
+      else
+        .error s!"the search returned {walk}, which is not a closed walk of odd length \
+          in the graph"
+
+end LeanHoG

--- a/LeanHoG/Invariant/Bipartite/Tactic.lean
+++ b/LeanHoG/Invariant/Bipartite/Tactic.lean
@@ -1,0 +1,194 @@
+import Lean
+import Qq
+import LeanHoG.LoadGraph
+import LeanHoG.Invariant.Bipartite.Certificate
+import LeanHoG.Invariant.Bipartite.Search
+
+namespace LeanHoG
+
+open Lean Elab Qq
+
+/-- The term to use as a certificate of type `certType`: the declaration `declName` if
+    it already holds one for this graph, a fresh declaration under that name if
+    `register` is set, and otherwise `cert` itself.
+
+    `#check_bipartite` wants a declaration, since registering a reusable certificate is
+    the whole point of the command.
+
+    The `check_bipartite` tactics must not ask for one. Lean elaborates declarations in
+    parallel and lets each add only names beneath its own prefix, so a named theorem
+    cannot introduce `G.TwoColoringI` and fails with `cannot add declaration ... as it
+    is restricted to the prefix ...`. With `register := false` the certificate goes
+    into the proof term directly. -/
+private def certificateTerm (declName : Name) (certType : Expr) (cert : Expr)
+    (register : Bool) : TermElabM Expr := do
+  if ← hasReusableDecl declName certType then
+    return mkConst declName
+  if register then
+    Lean.addAndCompile <| .defnDecl {
+      name := declName
+      levelParams := []
+      type := certType
+      value := cert
+      hints := .regular 0
+      safety := .safe
+    }
+    Meta.addInstance declName .global 42
+    return mkConst declName
+  return cert
+
+/-- Decide bipartiteness of `graph` by breadth-first search, and return the fact that
+    establishes, a proof of it, and which way the answer went.
+
+    `register` says whether the certificate should be backed by a declaration named
+    after the graph — the `TwoColoring` instance in the bipartite case, the
+    `OddClosedWalk` instance in the other. See `certificateTerm`. -/
+unsafe def searchForTwoColoringAux (graphName : Name) (graph : Q(Graph)) (register : Bool) :
+    TermElabM (Expr × Expr × Bool) := do
+  let G ← Meta.evalExpr' Graph ``Graph graph
+  match G.searchBipartite with
+  | .error msg => throwError "breadth-first search on {graphName} failed: {msg}"
+  | .ok (.twoColoring data) =>
+    let certType : Q(Type) := q(TwoColoring $graph)
+    let cert ← certificateTerm (certificateName graphName "TwoColoringI") certType
+      (TwoColoringOfData graph data) register
+    -- Applied to the certificate explicitly, not left to instance synthesis: `mkAppM`
+    -- with no arguments returns the bare constant, whose implicit `G` and instance are
+    -- still abstracted, and that only fails later in the kernel.
+    let proof ← Meta.mkAppOptM ``LeanHoG.TwoColoring.bipartite #[graph, cert]
+    return (q(Graph.bipartite $graph), proof, true)
+  | .ok (.oddClosedWalk data) =>
+    let certType : Q(Type) := q(OddClosedWalk $graph)
+    let cert ← certificateTerm (certificateName graphName "OddClosedWalkI") certType
+      (OddClosedWalkOfData graph data) register
+    let proof ← Meta.mkAppOptM ``LeanHoG.OddClosedWalk.not_bipartite #[graph, cert]
+    return (q(¬ Graph.bipartite $graph), proof, false)
+
+------------------------------------------
+-- Check bipartiteness command
+------------------------------------------
+
+syntax (name := checkBipartite) "#check_bipartite " ident : command
+/-- `#check_bipartite G` decides bipartiteness of the graph `G` by breadth-first
+    search, and registers a certificate for whichever answer it reaches:
+
+    * **Bipartite.** Coloring each vertex by the parity of its distance from the root of
+      its connected component gives a `TwoColoring G` instance.
+    * **Not bipartite.** Some edge joins two vertices of equal parity. That edge and the
+      two search-tree paths back to their common ancestor close a walk of odd length,
+      which gives an `OddClosedWalk G` instance.
+
+    Either instance makes `#eval G.bipartite` return without enumerating all `2^n` maps
+    `G.vertex → Fin 2`, which is what deciding bipartiteness on a bare graph does.
+
+    This is the *command* form: it reports what it found. It proves nothing about the
+    current goal — see the `check_bipartite` tactic for that. The two are independent:
+    the tactic does not require the command to have been run on `G` first.
+-/
+@[command_elab checkBipartite]
+unsafe def checkBipartiteImpl : Command.CommandElab
+  | `(#check_bipartite $g) => Command.liftTermElabM do
+    let graphName := g.getId
+    let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
+    let (_, _, bipartite) ← searchForTwoColoringAux graphName graph (register := true)
+    if bipartite then
+      logInfo m!"found a two-coloring, registered as \
+        {certificateName graphName "TwoColoringI"}"
+    else
+      logInfo m!"found an odd closed walk, registered as \
+        {certificateName graphName "OddClosedWalkI"}"
+
+  | _ => throwUnsupportedSyntax
+
+------------------------------------------
+-- Check bipartiteness tactic
+------------------------------------------
+
+/-- Run the bipartiteness search on `g` and add what it establishes to the local
+    context as a hypothesis named `h` — `g.bipartite` if the search two-colored the
+    graph, `¬ g.bipartite` if it found an odd closed walk. Shared by the
+    `check_bipartite` and `check_bipartitea` tactics.
+-/
+unsafe def assertBipartitenessFact (g : Ident) (h : Name) : Tactic.TacticM Unit :=
+  Tactic.withMainContext do
+    let graph ← Qq.elabTermEnsuringTypeQ g q(Graph)
+    let (type, proof, _) ← searchForTwoColoringAux g.getId graph (register := false)
+    Tactic.liftMetaTactic fun mvarId => do
+      let mvarIdNew ← mvarId.assert h type proof
+      let (_, mvarIdNew) ← mvarIdNew.intro1P
+      return [mvarIdNew]
+
+syntax (name := checkBipartiteTactic) "check_bipartite " ident (" with" (ppSpace colGt ident))? : tactic
+/-- `check_bipartite G` decides bipartiteness of the graph `G` by breadth-first search
+    and adds what it decided to the local context as a hypothesis. It serves goals of
+    both signs, and you do not have to know which way the answer goes before invoking
+    it.
+
+    * **Bipartite.** The hypothesis is `G.bipartite`, proved by the two-coloring the
+      search produced.
+    * **Not bipartite.** The hypothesis is `¬ G.bipartite`, proved by the odd closed
+      walk the search produced.
+
+    Neither depends on an axiom, and neither runs a solver.
+
+    **This tactic adds a hypothesis; it does not close the goal.** Finish with
+    `assumption`, or use `check_bipartitea`, which does that for you:
+
+    ```lean
+    example : Cycle7.bipartite → False := by
+      check_bipartite Cycle7
+      intro h; contradiction
+
+    example : Path1.bipartite := by
+      check_bipartite Path1
+      assumption
+    ```
+
+    `check_bipartite G with h` names the hypothesis `h` instead of leaving it
+    inaccessible:
+
+    ```lean
+    example : ¬Cycle7.bipartite := by
+      check_bipartite Cycle7 with h
+      exact h
+    ```
+-/
+@[tactic checkBipartiteTactic]
+unsafe def checkBipartiteTacticImpl : Tactic.Tactic
+  | `(tactic|check_bipartite $g) => assertBipartitenessFact g .anonymous
+  | `(tactic|check_bipartite $g with $h) => assertBipartitenessFact g h.getId
+  | _ => throwUnsupportedSyntax
+
+syntax (name := checkBipartiteaTactic) "check_bipartitea " ident : tactic
+/-- `check_bipartitea G` is `check_bipartite G` followed by `assumption`, in the same
+    spirit as `simpa` for `simp`: it derives the fact about bipartiteness of `G` and
+    then uses it to close the goal, rather than leaving it in the context. Like
+    `check_bipartite`, it decides bipartiteness in both directions:
+
+    ```lean
+    example : Path1.bipartite := by
+      check_bipartitea Path1
+
+    example : ¬Cycle7.bipartite := by
+      check_bipartitea Cycle7
+    ```
+
+    Use `check_bipartite` when the derived fact is a step rather than the whole proof.
+-/
+@[tactic checkBipartiteaTactic]
+unsafe def checkBipartiteaTacticImpl : Tactic.Tactic
+  | `(tactic|check_bipartitea $g) => do
+    assertBipartitenessFact g .anonymous
+    Tactic.withMainContext do
+      Tactic.liftMetaTactic fun mvarId => do
+        try
+          mvarId.assumption
+          return []
+        catch _ =>
+          throwError "check_bipartitea derived a fact about bipartiteness of {g}, but it \
+            does not close the goal. Use `check_bipartite {g} with h` to name it and \
+            finish the proof by hand."
+
+  | _ => throwUnsupportedSyntax
+
+end LeanHoG

--- a/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
+++ b/LeanHoG/Invariant/HamiltonianPath/Tactic.lean
@@ -11,28 +11,6 @@ namespace LeanHoG
 
 open Lean Elab Qq
 
-/-- Whether `declName` already holds a declaration of type `expectedType`, which a
-    previous run on the same graph would have left there and which can therefore be
-    reused instead of declared again.
-
-    The name existing is not on its own evidence that it holds such a declaration: the
-    names below are derived from the graph's, and nothing stops anything else in the
-    environment from having claimed one first. Reusing whatever is there would build a
-    term against the wrong type and only fail later, in the kernel, complaining about a
-    term the user never wrote. So a name held by something of another type is reported
-    here instead; the name is taken either way, and there is nothing useful to do but
-    say so.
-
-    The comparison runs at a new metavariable depth so that a mismatch cannot leave
-    `expectedType`'s metavariables assigned behind it. -/
-private def hasReusableDecl (declName : Name) (expectedType : Expr) : Meta.MetaM Bool := do
-  let some info := (← getEnv).find? declName | return false
-  if ← Meta.withNewMCtxDepth (Meta.isDefEq info.type (← instantiateMVars expectedType)) then
-    return true
-  else
-    throwError "the name {declName} is already taken by a declaration of type\
-      {indentExpr info.type}\nbut this graph needs one of type{indentExpr expectedType}"
-
 open Trestle Model in
 /-- Decide traceability of `graph` with the SAT solver, and return the fact that
     establishes, a proof of it, and the solver's answer.

--- a/LeanHoG/LoadGraph.lean
+++ b/LeanHoG/LoadGraph.lean
@@ -9,6 +9,7 @@ import LeanHoG.Invariant.ConnectedComponents.Certificate
 import LeanHoG.Invariant.NeighborhoodMap.Certificate
 
 import LeanHoG.Certificate
+import LeanHoG.Util.Meta
 import LeanHoG.JsonData
 
 import Trestle.Solver.Impl.DimacsCommand

--- a/LeanHoG/Util.lean
+++ b/LeanHoG/Util.lean
@@ -1,5 +1,6 @@
 import LeanHoG.Util.LeanSAT
 import LeanHoG.Util.List
+import LeanHoG.Util.Meta
 import LeanHoG.Util.PackageDir
 import LeanHoG.Util.Quote
 import LeanHoG.Util.RB

--- a/LeanHoG/Util/Meta.lean
+++ b/LeanHoG/Util/Meta.lean
@@ -1,0 +1,18 @@
+import Lean
+
+namespace LeanHoG
+
+open Lean
+
+/-- Whether `declName` already holds a declaration of type `expectedType`. -/
+def hasReusableDecl (declName : Name) (expectedType : Expr) : Meta.MetaM Bool := do
+  let some info := (← getEnv).find? declName | return false
+  -- The comparison runs at a new metavariable depth so that a mismatch cannot leave
+  -- `expectedType`'s metavariables assigned behind it.
+  if ← Meta.withNewMCtxDepth (Meta.isDefEq info.type (← instantiateMVars expectedType)) then
+    return true
+  else
+    throwError "the name {declName} is already taken by a declaration of type\
+      {indentExpr info.type}\nbut this graph needs one of type{indentExpr expectedType}"
+
+end LeanHoG

--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ Neither command attaches any invariant certificate, so invariants of a graph rea
 Only graph6 is supported; sparse6, the `:`-prefixed format, is not.
 
 
+### Deciding bipartiteness
+
+Without a certificate, `Graph.bipartite` is decided by enumerating all `2^n` maps `G.vertex → Fin 2`, which is out of reach past a couple of dozen vertices. `#check_bipartite <graphName>` decides it by breadth-first search instead, and registers the certificate for whichever answer it reaches: a `TwoColoring` if the graph is bipartite, an `OddClosedWalk` if it is not. Later invariant queries read the answer off that certificate.
+
+```lean
+load_graph_from_g6 Petersen "IsP@OkWHG"
+#check_bipartite Petersen
+#eval Petersen.bipartite
+```
+
+The command reports what it found. The tactic `check_bipartite <graphName>` puts the fact into a proof, adding `G.bipartite` or `¬ G.bipartite` to the context as a hypothesis; `check_bipartite <graphName> with h` names it, and `check_bipartitea <graphName>` closes the goal with it directly. No solver is involved and no axiom is asserted: the kernel checks the certificate the search produced.
+
+```lean
+example : ¬Petersen.bipartite := by
+  check_bipartitea Petersen
+```
+
+
 ### Visualization widget
 
 Lean-HoG can visualize the imported graphs in the Lean infoview using 


### PR DESCRIPTION
Closes #76.

`TwoColoring` and `OddClosedWalk` were certificates nothing in the repo ever computed — `TwoColoringOfData` and `OddClosedWalkOfData` were called only from `LoadGraph.lean`, reading a field out of the JSON. A graph whose JSON omits the field falls to the generic `Decidable` instance, which enumerates all `2^n` maps `G.vertex → Fin 2`.

`LeanHoG/Invariant/Bipartite/Search.lean` decides bipartiteness by breadth-first search: root a tree in each connected component, colour each vertex by the parity of its distance from the root. If no edge joins two vertices of the same colour, the colouring is a `TwoColoringData`. If one does, that edge together with the two tree paths back to the common ancestor of its endpoints closes a walk of odd length, which is an `OddClosedWalkData`. It is pure Lean over the edge set, with no dependency outside the repo.

`LeanHoG/Invariant/Bipartite/Tactic.lean` adds `#check_bipartite G`, which registers whichever certificate the search reached as an instance, and the tactics `check_bipartite G`, `check_bipartite G with h` and `check_bipartitea G`, which put the fact into a proof. The BFS needs no correctness proof: the certificate constructors discharge their obligations by `Eq.refl` at `decide`, so a bug in the search produces a certificate that fails to typecheck. The search's answer is checked against the graph before the certificate is built, so a search that goes wrong reports that rather than a kernel type mismatch in a term nobody wrote. No solver, no subprocess, no axiom — `#print axioms` on a proof by `check_bipartitea` shows only `propext`, `Classical.choice` and `Quot.sound`.

Supporting changes: `TwoColoring.bipartite`, the positive counterpart of the existing `OddClosedWalk.not_bipartite`, so the two branches of the tactic are symmetric; and `hasReusableDecl` moves from `HamiltonianPath/Tactic.lean`, where it was private, into `LeanHoG/Util/Meta.lean`, so both tactics share it. A graph that already carries a certificate from its JSON gets that one rather than a clash.

`set_option maxRecDepth 10000` is gone from the capstone theorem in `Examples.lean`. It was there because `decide` on `¬Twin1.bipartite` searches for a two-colouring and overruns the default budget; `check_bipartitea` replaces those two `decide`s. The theorem's axiom set is unchanged.

`Examples.lean` gains a bipartiteness section — `#eval Cube5.bipartite`, commented out there as unrunnable on 32 vertices, now evaluates — and the README a section on the command and the tactics.

*— Claude (Claude Code), posting from @lucyhorowitz's account*
