### PR TITLE
send the right invariant ids to HoG in the search DSL

### DIFF
--- a/LeanHoG/Tactic/SearchDSL.lean
+++ b/LeanHoG/Tactic/SearchDSL.lean
@@ -47,6 +47,7 @@ instance : ToString BoolInvariant where
 inductive NumericalInvariant where
   | AlgebraicConnectivity
   | AverageDegree
+  | Density
   | Index
   | LaplacianLargestEigenvalue
   | SecondLargestEigenvalue
@@ -58,6 +59,7 @@ instance : ToString NumericalInvariant where
     match i with
     | .AlgebraicConnectivity => "AlgebraicConnectivity"
     | .AverageDegree => "AverageDegree"
+    | .Density => "Density"
     | .Index => "Index"
     | .LaplacianLargestEigenvalue => "LaplacianLargestEigenvalue"
     | .SecondLargestEigenvalue => "SecondLargestEigenvalue"
@@ -69,7 +71,6 @@ inductive IntegralInvariant
   | Circumference
   | CliqueNumber
   | Degeneracy
-  | Density
   | Diameter
   | DominationNumber
   | EdgeConnectivity
@@ -78,13 +79,16 @@ inductive IntegralInvariant
   | Girth
   | GroupSize
   | IndependenceNumber
+  | IndependentDominationNumber
   | LengthOfLongestInducedCycle
   | LengthOfLongestInducedPath
   | LengthOfLongestPath
   | MatchingNumber
   | MaximumDegree
   | MinimumDegree
+  | NumberOfArcOrbits
   | NumberOfComponents
+  | NumberOfEdgeOrbits
   | NumberOfEdges
   | NumberOfSpanningTrees
   | NumberOfTriangles
@@ -105,7 +109,6 @@ instance : ToString IntegralInvariant where
     | .Circumference => "Circumference"
     | .CliqueNumber => "CliqueNumber"
     | .Degeneracy => "Degeneracy"
-    | .Density => "Density"
     | .Diameter => "Diameter"
     | .DominationNumber => "DominationNumber"
     | .EdgeConnectivity => "EdgeConnectivity"
@@ -114,13 +117,16 @@ instance : ToString IntegralInvariant where
     | .Girth => "Girth"
     | .GroupSize => "GroupSize"
     | .IndependenceNumber => "IndependenceNumber"
+    | .IndependentDominationNumber => "IndependentDominationNumber"
     | .LengthOfLongestInducedCycle => "LengthOfLongestInducedCycle"
     | .LengthOfLongestInducedPath => "LengthOfLongestInducedPath"
     | .LengthOfLongestPath => "LengthOfLongestPath"
     | .MatchingNumber => "MatchingNumber"
     | .MaximumDegree => "MaximumDegree"
     | .MinimumDegree => "MinimumDegree"
+    | .NumberOfArcOrbits => "NumberOfArcOrbits"
     | .NumberOfComponents => "NumberOfComponents"
+    | .NumberOfEdgeOrbits => "NumberOfEdgeOrbits"
     | .NumberOfEdges => "NumberOfEdges"
     | .NumberOfSpanningTrees => "NumberOfSpanningTrees"
     | .NumberOfTriangles => "NumberOfTriangles"
@@ -156,7 +162,7 @@ def BoolInvariant.toId : BoolInvariant → Nat
   | .Hypohamiltonian => 41
   | .Hypotraceable => 42
   | .Planar => 36
-  | .Regular => 18
+  | .Regular => 17
   | .Traceable => 40
   | .TwinFree => 46
 
@@ -164,6 +170,7 @@ def BoolInvariant.toId : BoolInvariant → Nat
 def NumericalInvariant.toId : NumericalInvariant → Nat
   | .AlgebraicConnectivity => 19
   | .AverageDegree => 2
+  | .Density => 34
   | .Index => 21
   | .LaplacianLargestEigenvalue => 22
   | .SecondLargestEigenvalue => 23
@@ -175,8 +182,7 @@ def IntegralInvariant.toId : IntegralInvariant → Nat
   | .ChromaticNumber => 4
   | .Circumference => 35
   | .CliqueNumber => 5
-  | .Degeneracy => 48
-  | .Density => 34
+  | .Degeneracy => 49
   | .Diameter => 7
   | .DominationNumber => 13
   | .EdgeConnectivity => 8
@@ -185,13 +191,16 @@ def IntegralInvariant.toId : IntegralInvariant → Nat
   | .Girth => 9
   | .GroupSize => 37
   | .IndependenceNumber => 18
+  | .IndependentDominationNumber => 52
   | .LengthOfLongestInducedCycle => 31
   | .LengthOfLongestInducedPath => 25
   | .LengthOfLongestPath => 48
   | .MatchingNumber => 11
   | .MaximumDegree => 10
   | .MinimumDegree => 12
+  | .NumberOfArcOrbits => 51
   | .NumberOfComponents => 26
+  | .NumberOfEdgeOrbits => 50
   | .NumberOfEdges => 14
   | .NumberOfSpanningTrees => 43
   | .NumberOfTriangles => 27
@@ -396,6 +405,7 @@ def boolInvariantToQuery : BoolInvariant → Bool → GraphClassQuery
 def numericalInvariantToQuery : NumericalInvariant → ComparisonOp → Float → InvariantQuery
   | .AlgebraicConnectivity, op, x => ⟨(Invariant.NumericalInvariant .AlgebraicConnectivity).toId, toString op, x⟩
   | .AverageDegree, op, x => ⟨(Invariant.NumericalInvariant .AverageDegree).toId, toString op, x⟩
+  | .Density, op, x => ⟨(Invariant.NumericalInvariant .Density).toId, toString op, x⟩
   | .Index, op, x => ⟨(Invariant.NumericalInvariant .Index).toId, toString op, x⟩
   | .LaplacianLargestEigenvalue, op, x => ⟨(Invariant.NumericalInvariant .LaplacianLargestEigenvalue).toId, toString op, x⟩
   | .SecondLargestEigenvalue, op, x => ⟨(Invariant.NumericalInvariant .SecondLargestEigenvalue).toId, toString op, x⟩
@@ -407,7 +417,6 @@ def integralInvariantToQuery : IntegralInvariant → ComparisonOp → Int → In
   | .Circumference, op, n => ⟨(Invariant.IntegralInvariant .Circumference).toId, toString op, .ofInt n⟩
   | .CliqueNumber, op, n => ⟨(Invariant.IntegralInvariant .CliqueNumber).toId, toString op, .ofInt n⟩
   | .Degeneracy, op, n => ⟨(Invariant.IntegralInvariant .Degeneracy).toId, toString op, .ofInt n⟩
-  | .Density, op, n => ⟨(Invariant.IntegralInvariant .Density).toId, toString op, .ofInt n⟩
   | .Diameter, op, n => ⟨(Invariant.IntegralInvariant .Diameter).toId, toString op, .ofInt n⟩
   | .DominationNumber, op, n => ⟨(Invariant.IntegralInvariant .DominationNumber).toId, toString op, .ofInt n⟩
   | .EdgeConnectivity, op, n => ⟨(Invariant.IntegralInvariant .EdgeConnectivity).toId, toString op, .ofInt n⟩
@@ -416,13 +425,16 @@ def integralInvariantToQuery : IntegralInvariant → ComparisonOp → Int → In
   | .Girth, op, n => ⟨(Invariant.IntegralInvariant .Girth).toId, toString op, .ofInt n⟩
   | .GroupSize, op, n => ⟨(Invariant.IntegralInvariant .GroupSize).toId, toString op, .ofInt n⟩
   | .IndependenceNumber, op, n => ⟨(Invariant.IntegralInvariant .IndependenceNumber).toId, toString op, .ofInt n⟩
+  | .IndependentDominationNumber, op, n => ⟨(Invariant.IntegralInvariant .IndependentDominationNumber).toId, toString op, .ofInt n⟩
   | .LengthOfLongestInducedCycle, op, n => ⟨(Invariant.IntegralInvariant .LengthOfLongestInducedCycle).toId, toString op, .ofInt n⟩
   | .LengthOfLongestInducedPath, op, n => ⟨(Invariant.IntegralInvariant .LengthOfLongestInducedPath).toId, toString op, .ofInt n⟩
   | .LengthOfLongestPath, op, n => ⟨(Invariant.IntegralInvariant .LengthOfLongestPath).toId, toString op, .ofInt n⟩
   | .MatchingNumber, op, n => ⟨(Invariant.IntegralInvariant .MatchingNumber).toId, toString op, .ofInt n⟩
   | .MaximumDegree, op, n => ⟨(Invariant.IntegralInvariant .MaximumDegree).toId, toString op, .ofInt n⟩
   | .MinimumDegree, op, n => ⟨(Invariant.IntegralInvariant .MinimumDegree).toId, toString op, .ofInt n⟩
+  | .NumberOfArcOrbits, op, n => ⟨(Invariant.IntegralInvariant .NumberOfArcOrbits).toId, toString op, .ofInt n⟩
   | .NumberOfComponents, op, n => ⟨(Invariant.IntegralInvariant .NumberOfComponents).toId, toString op, .ofInt n⟩
+  | .NumberOfEdgeOrbits, op, n => ⟨(Invariant.IntegralInvariant .NumberOfEdgeOrbits).toId, toString op, .ofInt n⟩
   | .NumberOfEdges, op, n => ⟨(Invariant.IntegralInvariant .NumberOfEdges).toId, toString op, .ofInt n⟩
   | .NumberOfSpanningTrees, op, n => ⟨(Invariant.IntegralInvariant .NumberOfSpanningTrees).toId, toString op, .ofInt n⟩
   | .NumberOfTriangles, op, n => ⟨(Invariant.IntegralInvariant .NumberOfTriangles).toId, toString op, .ofInt n⟩
@@ -512,7 +524,6 @@ syntax "chromaticNumber" : integral_invariant
 syntax "circumference" : integral_invariant
 syntax "cliqueNumber" : integral_invariant
 syntax "degeneracy" : integral_invariant
-syntax "density" : integral_invariant
 syntax "diameter" : integral_invariant
 syntax "dominationNumber" : integral_invariant
 syntax "edgeConnectivity" : integral_invariant
@@ -521,13 +532,16 @@ syntax "genus" : integral_invariant
 syntax "girth" : integral_invariant
 syntax "groupSize" : integral_invariant
 syntax "independenceNumber" : integral_invariant
+syntax "independentDominationNumber" : integral_invariant
 syntax "lengthOfLongestInducedCycle" : integral_invariant
 syntax "lengthOfLongestInducedPath" : integral_invariant
 syntax "lengthOfLongestPath" : integral_invariant
 syntax "matchingNumber" : integral_invariant
 syntax "maximumDegree" : integral_invariant
 syntax "minimumDegree" : integral_invariant
+syntax "numberOfArcOrbits" : integral_invariant
 syntax "numberOfComponents" : integral_invariant
+syntax "numberOfEdgeOrbits" : integral_invariant
 syntax "numberOfEdges" : integral_invariant
 syntax "numberOfSpanningTrees" : integral_invariant
 syntax "numberOfTriangles" : integral_invariant
@@ -543,6 +557,7 @@ declare_syntax_cat numerical_invariant
 
 syntax "algebraicConnectivity" : numerical_invariant
 syntax "averageDegree" : numerical_invariant
+syntax "density" : numerical_invariant
 syntax "index" : numerical_invariant
 syntax "laplacianLargestEigenvalue" : numerical_invariant
 syntax "secondLargestEigenvalue" : numerical_invariant
@@ -599,7 +614,6 @@ macro_rules
   | `(fmla!{circumference}) => `(ArithExpr.integralInv .Circumference)
   | `(fmla!{cliqueNumber}) => `(ArithExpr.integralInv .CliqueNumber)
   | `(fmla!{degeneracy}) => `(ArithExpr.integralInv .Degeneracy)
-  | `(fmla!{density}) => `(ArithExpr.integralInv .Density)
   | `(fmla!{diameter}) => `(ArithExpr.integralInv .Diameter)
   | `(fmla!{dominationNumber}) => `(ArithExpr.integralInv .DominationNumber)
   | `(fmla!{edgeConnectivity}) => `(ArithExpr.integralInv .EdgeConnectivity)
@@ -608,13 +622,16 @@ macro_rules
   | `(fmla!{girth}) => `(ArithExpr.integralInv .Girth)
   | `(fmla!{groupSize}) => `(ArithExpr.integralInv .GroupSize)
   | `(fmla!{independenceNumber}) => `(ArithExpr.integralInv .IndependenceNumber)
+  | `(fmla!{independentDominationNumber}) => `(ArithExpr.integralInv .IndependentDominationNumber)
   | `(fmla!{lengthOfLongestInducedCycle}) => `(ArithExpr.integralInv .LengthOfLongestInducedCycle)
   | `(fmla!{lengthOfLongestInducedPath}) => `(ArithExpr.integralInv .LengthOfLongestInducedPath)
   | `(fmla!{lengthOfLongestPath}) => `(ArithExpr.integralInv .LengthOfLongestPath)
   | `(fmla!{matchingNumber}) => `(ArithExpr.integralInv .MatchingNumber)
   | `(fmla!{maximumDegree}) => `(ArithExpr.integralInv .MaximumDegree)
   | `(fmla!{minimumDegree}) => `(ArithExpr.integralInv .MinimumDegree)
+  | `(fmla!{numberOfArcOrbits}) => `(ArithExpr.integralInv .NumberOfArcOrbits)
   | `(fmla!{numberOfComponents}) => `(ArithExpr.integralInv .NumberOfComponents)
+  | `(fmla!{numberOfEdgeOrbits}) => `(ArithExpr.integralInv .NumberOfEdgeOrbits)
   | `(fmla!{numberOfEdges}) => `(ArithExpr.integralInv .NumberOfEdges)
   | `(fmla!{numberOfSpanningTrees}) => `(ArithExpr.integralInv .NumberOfSpanningTrees)
   | `(fmla!{numberOfTriangles}) => `(ArithExpr.integralInv .NumberOfTriangles)
@@ -627,6 +644,7 @@ macro_rules
   | `(fmla!{vertexCoverNumber}) => `(ArithExpr.integralInv .VertexCoverNumber)
   | `(fmla!{algebraicConnectivity}) => `(ArithExpr.numericalInv .AlgebraicConnectivity)
   | `(fmla!{averageDegree}) => `(ArithExpr.numericalInv .AverageDegree)
+  | `(fmla!{density}) => `(ArithExpr.numericalInv .Density)
   | `(fmla!{index}) => `(ArithExpr.numericalInv .Index)
   | `(fmla!{laplacianLargestEigenvalue}) => `(ArithExpr.numericalInv .LaplacianLargestEigenvalue)
   | `(fmla!{secondLargestEigenvalue}) => `(ArithExpr.numericalInv .SecondLargestEigenvalue)
@@ -663,6 +681,7 @@ syntax:max "(" hog_query ")" : hog_query
   -- Numerical invariants
   | `(hog{algebraicConnectivity $op $x}) => `([[HoGEnquiry.NumericalEnquiry ⟨.AlgebraicConnectivity, op!{$op}, $x⟩]])
   | `(hog{averageDegree $op $x}) => `([[HoGEnquiry.NumericalEnquiry ⟨.AverageDegree, op!{$op}, $x⟩]])
+  | `(hog{density $op $x}) => `([[HoGEnquiry.NumericalEnquiry ⟨.Density, op!{$op}, $x⟩]])
   | `(hog{index $op $x}) => `([[HoGEnquiry.NumericalEnquiry ⟨.Index, op!{$op}, $x⟩]])
   | `(hog{laplacianLargestEigenvalue $op $x}) => `([[HoGEnquiry.NumericalEnquiry ⟨.LaplacianLargestEigenvalue, op!{$op}, $x⟩]])
   | `(hog{secondLargestEigenvalue $op $x}) => `([[HoGEnquiry.NumericalEnquiry ⟨.SecondLargestEigenvalue, op!{$op}, $x⟩]])
@@ -674,7 +693,6 @@ syntax:max "(" hog_query ")" : hog_query
   | `(hog{circumference $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.Circumference, op!{$op}, $n⟩]])
   | `(hog{cliqueNumber $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.CliqueNumber, op!{$op}, $n⟩]])
   | `(hog{degeneracy $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.Degeneracy, op!{$op}, $n⟩]])
-  | `(hog{density $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.Density, op!{$op}, $n⟩]])
   | `(hog{diameter $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.Diameter, op!{$op}, $n⟩]])
   | `(hog{dominationNumber $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.DominationNumber, op!{$op}, $n⟩]])
   | `(hog{edgeConnectivity $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.EdgeConnectivity, op!{$op}, $n⟩]])
@@ -683,13 +701,16 @@ syntax:max "(" hog_query ")" : hog_query
   | `(hog{girth $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.Girth, op!{$op}, $n⟩]])
   | `(hog{groupSize $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.GroupSize, op!{$op}, $n⟩]])
   | `(hog{independenceNumber $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.IndependenceNumber, op!{$op}, $n⟩]])
+  | `(hog{independentDominationNumber $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.IndependentDominationNumber, op!{$op}, $n⟩]])
   | `(hog{lengthOfLongestInducedCycle $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.LengthOfLongestInducedCycle, op!{$op}, $n⟩]])
   | `(hog{lengthOfLongestInducedPath $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.LengthOfLongestInducedPath, op!{$op}, $n⟩]])
   | `(hog{lengthOfLongestPath $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.LengthOfLongestPath, op!{$op}, $n⟩]])
   | `(hog{matchingNumber $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.MatchingNumber, op!{$op}, $n⟩]])
   | `(hog{maximumDegree $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.MaximumDegree, op!{$op}, $n⟩]])
   | `(hog{minimumDegree $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.MinimumDegree, op!{$op}, $n⟩]])
+  | `(hog{numberOfArcOrbits $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.NumberOfArcOrbits, op!{$op}, $n⟩]])
   | `(hog{numberOfComponents $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.NumberOfComponents, op!{$op}, $n⟩]])
+  | `(hog{numberOfEdgeOrbits $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.NumberOfEdgeOrbits, op!{$op}, $n⟩]])
   | `(hog{numberOfEdges $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.NumberOfEdges, op!{$op}, $n⟩]])
   | `(hog{numberOfSpanningTrees $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.NumberOfSpanningTrees, op!{$op}, $n⟩]])
   | `(hog{numberOfTriangles $op $n}) => `([[HoGEnquiry.IntegralEnquiry ⟨.NumberOfTriangles, op!{$op}, $n⟩]])

--- a/README.md
+++ b/README.md
@@ -236,14 +236,12 @@ Consult the (`examples`)[./examples] folder.
 }
 ```
 
-### Bipartite
+### Two-coloring
 
 ```json
-"bipartite" : {
+"twoColoring" : {
   "color" : <map vertices to color, 0 or 1>,
-  "vertex0" : <vertex with color 0>,
-  "vertex1" : <vertex with color 1>,
-},
+}
 ```
 
 ### Odd closed walk


### PR DESCRIPTION
Closes #78.

HoG's enquiry API identifies an invariant only by its numeric id, so a wrong entry in the `toId` tables makes the server answer a different question with no error anywhere. `Regular` was mapped to 18, the id of Independence Number, and `Degeneracy` to 48, which the same table already used for `LengthOfLongestPath`.

Measured against the live API, before and after:

| Query | id sent | Result |
|---|---|---|
| `hog{ regular = true }` | 18 | 47 graphs |
| corrected | 17 | 11931 graphs, all with `minDegree = maxDegree` |
| `hog{ degeneracy = 3 }` | 48 | 84 graphs, of degeneracy 1 and 2 |
| corrected | 49 | 14450 graphs, all of degeneracy 3 |

`Density` moves from `IntegralInvariant` to `NumericalInvariant`. HoG types it real, and as an integral invariant its enquiry value was an `Int`, so `hog{ density > 0.3 }` could not be written at all.

Number of Edge Orbits (50), Number of Arc Orbits (51) and Independent Domination Number (52) had no constructor and are added, which brings the DSL to all 52 of HoG's invariants.

Second commit is unrelated but tiny: the README's raw data section described the bipartiteness certificate as a `"bipartite"` object with `color`, `vertex0` and `vertex1` fields. The key `JsonData.lean` actually reads is `"twoColoring"` and its only field is `color`.

### Checking

I diffed all 52 constructor-to-id pairs against a live `GET /api/invariants` and asserted no duplicate ids, rather than eyeballing the six entries I touched — the two bugs here were both of the kind eyeballing misses. `lake build LeanHoG.Tactic.SearchDSL` is green. The corrected `regular` and `degeneracy` queries were run against the live API and the returned graphs spot-checked against their own invariant values, which is the table above.

Not addressed here: the three `TODO`s in that file asking for these tables to be generated from HoG rather than hand-maintained. That is the fix that stops this recurring, and `/api/invariants` is public and returns 200 unauthenticated, so it is not blocked on anything except wanting a committed copy of the invariant list to generate against. Worth its own PR.

Branched off `main` and independent of #77 — the two touch different regions of `README.md` and merge cleanly in either order.

*— Claude (Claude Code), posting from @lucyhorowitz's account*
